### PR TITLE
Lifting property outputs and optional resource args

### DIFF
--- a/experimental/src/main/scala/besom/liftoff.scala
+++ b/experimental/src/main/scala/besom/liftoff.scala
@@ -1,23 +1,26 @@
 //> using dep "org.virtuslab::besom-kubernetes:0.0.1-SNAPSHOT"
 
-import besom.*, api.{kubernetes => k8s}
+import besom.*, util.NonEmptyString
+import besom.api.{kubernetes => k8s}
 
 import k8s.core.v1.inputs.*
 import k8s.apps.v1.inputs.*
 import k8s.meta.v1.inputs.*
 import k8s.core.v1.ConfigMap
 import k8s.apps.v1.{deployment, DeploymentArgs}
-import k8s.core.v1.{configMap, ConfigMapArgs, service, ServiceArgs}
+import k8s.core.v1.{configMap, ConfigMapArgs, namespace, service, ServiceArgs}
 
 @main
 def main(): Unit = Pulumi.run {
   val labels = Map("app" -> "nginx")
+  val appNamespace = namespace("liftoff")
 
   val indexHtmlConfigMap = configMap(
     "index-html-configmap",
     ConfigMapArgs(
       metadata = ObjectMetaArgs(
-        name = "index-html-configmap"
+        name = "index-html-configmap",
+        namespace = appNamespace.metadata.name.map(_.get),
       ),
       data = Map(
         "index.html" -> "<html><head><title>Infrastructure as Types: Pulumi and Scala</title></head><h1>WELCOME TO BESOM!</h1></br>></html>" // TODO paste a nice scala logotype and center everything nicely
@@ -34,7 +37,8 @@ def main(): Unit = Pulumi.run {
         template = PodTemplateSpecArgs(
           metadata = ObjectMetaArgs(
             name = "nginx-deployment",
-            labels = labels
+            labels = labels,
+            namespace = appNamespace.metadata.name.map(_.get)
           ),
           spec = PodSpecArgs(
             containers = ContainerArgs(
@@ -61,6 +65,9 @@ def main(): Unit = Pulumi.run {
             )
           )
         )
+      ),
+      metadata = ObjectMetaArgs(
+        namespace = appNamespace.metadata.name.map(_.get)
       )
     )
   )
@@ -73,11 +80,15 @@ def main(): Unit = Pulumi.run {
         ports = List(
           ServicePortArgs(name = "http", port = 80)
         )
+      ),
+      metadata = ObjectMetaArgs(
+        namespace = appNamespace.metadata.name.map(_.get)
       )
     )
   )
 
   for
+    _       <- appNamespace
     _       <- indexHtmlConfigMap
     nginx   <- nginxDeployment
     service <- nginxService


### PR DESCRIPTION
* Generate mapping and flatMapping extension proxies for Outputs of provider specific types
* Allow skipping resource args if they have a default
* Fix escaping keywords in extension names