### PR TITLE
AWS codegen tweaks

### DIFF
--- a/besom-cats/project.scala
+++ b/besom-cats/project.scala
@@ -1,4 +1,4 @@
-//> using scala "3.2.2"
+//> using scala "3.3.0"
 
 //> using file "../core/src/test/scala/besom/internal/ResultSpec.scala"
 //> using file "../core/src/test/scala/besom/internal/RunResult.scala"

--- a/besom-zio/project.scala
+++ b/besom-zio/project.scala
@@ -1,4 +1,4 @@
-//> using scala "3.2.2"
+//> using scala "3.3.0"
 
 //> using file "../core/src/test/scala/besom/internal/ResultSpec.scala"
 //> using file "../core/src/test/scala/besom/internal/RunResult.scala"

--- a/builder.toml
+++ b/builder.toml
@@ -1,0 +1,17 @@
+scalaVersion = "3.3.0"
+
+[modules.besom-zio]
+platforms = ["jvm"]
+dependsOn = ["core"]
+
+
+[modules.besom-cats]
+platforms = ["jvm"]
+dependsOn = ["core"]
+
+[modules.core]
+platforms = ["jvm"]
+
+[modules.codegen]
+platforms = ["jvm"]
+scalaVersion = "2.13.10"

--- a/codegen/project.scala
+++ b/codegen/project.scala
@@ -1,3 +1,4 @@
 //> using scala "2.13.10"
-//> using lib "org.scalameta::scalameta:4.7.7"
+//> using lib "org.scalameta::scalameta:4.7.8"
 //> using lib "com.lihaoyi::upickle:3.1.0"
+//> using lib "com.lihaoyi::os-lib:0.9.1"

--- a/codegen/src/Config.scala
+++ b/codegen/src/Config.scala
@@ -1,0 +1,16 @@
+package besom.codegen
+
+object Config {
+  case class ProviderConfig(
+    noncompiledModules: Seq[String] = Seq.empty
+  )
+  
+  val providersConfigs = Map(
+    "aws" -> ProviderConfig(
+      noncompiledModules = Seq(
+        "quicksight", // Module too large
+        "wafv2" // Module too large
+      )
+    )
+  ).withDefaultValue(ProviderConfig())
+}

--- a/codegen/src/Logger.scala
+++ b/codegen/src/Logger.scala
@@ -1,0 +1,15 @@
+package besom.codegen
+
+import scala.collection.mutable.ListBuffer
+
+class Logger {
+  private val buffer = ListBuffer.empty[String]
+
+  def warn(message: String): Unit =
+    buffer.append(s"Warning: ${message}\n" )
+
+  def writeToFile(file: os.Path): Unit =
+    os.write(file, buffer)
+
+  def nonEmpty = buffer.nonEmpty
+}

--- a/codegen/src/Main.scala
+++ b/codegen/src/Main.scala
@@ -1,38 +1,53 @@
 package besom.codegen
 
 import java.util.Arrays
-import java.io.File
-import java.nio.file.Files
 
 object Main {
   def main(args: Array[String]): Unit = {
     args.toList match {
-      case schemasDirPath :: outputDirBasePath :: packageName :: Nil =>
+      case schemasDirPath :: outputDirBasePath :: providerName :: Nil =>
         generatePackageSources(
-          schemasDirPath = schemasDirPath,
-          outputDirBasePath = outputDirBasePath,
-          packageName = packageName
+          schemasDirPath = os.Path(schemasDirPath),
+          outputDirBasePath = os.Path(outputDirBasePath),
+          providerName = providerName
         )
       case _ =>
-        System.err.println("Codegen's expected arguments: <schemasDirPath> <outputDirBasePath> <packageName>")
+        System.err.println("Codegen's expected arguments: <schemasDirPath> <outputDirBasePath> <providerName>")
         sys.exit(1)
     }
   }
 
-  def generatePackageSources(schemasDirPath: String, outputDirBasePath: String, packageName: String): Unit = {
-    val schemaFilePath = s"${schemasDirPath}/${packageName}.json"
-    val destinationDir = new File(s"${outputDirBasePath}/${packageName}")
-    destinationDir.delete()
+  def generatePackageSources(schemasDirPath: os.Path, outputDirBasePath: os.Path, providerName: String): Unit = {
+    val schemaFilePath = schemasDirPath / s"${providerName}.json"
+    val destinationDir = outputDirBasePath / providerName
+
+    println(s"Generating provider SDK for $providerName")
+
+    os.remove.all(destinationDir)
+    os.makeDir.all(destinationDir)
 
     val pulumiPackage = metaschema.PulumiPackage.fromFile(schemaFilePath)
+    val providerConfig = Config.providersConfigs(providerName)
 
-    CodeGen.sourcesFromPulumiPackage(
-      pulumiPackage,
-      besomVersion = "0.0.1-SNAPSHOT"
-    ).foreach { sourceFile =>
-      val absolutePath = destinationDir.toPath.resolve(sourceFile.relativePath).toAbsolutePath.normalize
-      absolutePath.getParent.toFile.mkdirs()
-      Files.write(absolutePath, sourceFile.sourceCode.getBytes)
+    implicit val logger: Logger = new Logger
+
+    try {
+      CodeGen.sourcesFromPulumiPackage(
+        pulumiPackage,
+        providerConfig,
+        besomVersion = "0.0.1-SNAPSHOT"
+      ).foreach { sourceFile =>
+        val filePath = destinationDir / sourceFile.filePath.osSubPath
+        os.makeDir.all(filePath / os.up)
+        os.write(filePath, sourceFile.sourceCode)
+      }
+      println("Finished generating SDK codebase")
+    } finally {
+      if (logger.nonEmpty) {
+        val logFile = destinationDir / ".codegen-log.txt"
+        println(s"Some problems were encountered during the code generation. See ${logFile}")
+        logger.writeToFile(logFile)
+      }
     }
   }
 }

--- a/codegen/src/PulumiPackage.scala
+++ b/codegen/src/PulumiPackage.scala
@@ -10,8 +10,8 @@ case class PulumiPackage(name: String, version: String, language: Language = Lan
 object PulumiPackage {
   implicit val reader: Reader[PulumiPackage] = macroR
 
-  def fromFile(filePath: String) = {
-    val input = ujson.Readable.fromFile(new File(filePath))
+  def fromFile(filePath: os.Path) = {
+    val input = os.read(filePath)
     val json = ujson.read(input)
     read[PulumiPackage](json)
   }
@@ -188,10 +188,8 @@ case class PropertyDefinition(
   // language: ,
   replaceOnChanges: Boolean = false,
   willReplaceOnChanges: Boolean = false,
-  secret: Boolean = false,
-
-  
-) //extends TypeReference
+  secret: Boolean = false
+)
 object PropertyDefinition {
   implicit val reader: Reader[PropertyDefinition] = PropertyDefinitionProto.reader.map { proto =>
     PropertyDefinition(
@@ -209,7 +207,7 @@ object PropertyDefinition {
 
 
 // TODO Handle `value`s of other primitive types
-case class EnumValueDefinition(value: String, name: Option[String] = None, description: Option[String] = None, deprecationMessage: Option[String] = None)
+case class EnumValueDefinition(value: ConstValue, name: Option[String] = None, description: Option[String] = None, deprecationMessage: Option[String] = None)
 object EnumValueDefinition {
   implicit val reader: Reader[EnumValueDefinition] = macroR
 }
@@ -229,4 +227,5 @@ object TypeDefinition {
 }
 
 case class EnumTypeDefinition(`enum`: List[EnumValueDefinition], `type`: PrimitiveType, isOverlay: Boolean) extends TypeDefinition
+
 case class ObjectTypeDefinition(properties: Map[String, PropertyDefinition], required: List[String] = Nil, isOverlay: Boolean) extends TypeDefinition with ObjectTypeDetails

--- a/core/project.scala
+++ b/core/project.scala
@@ -1,4 +1,4 @@
-//> using scala "3.2.2"
+//> using scala "3.3.0"
 
 //> using publish.organization "org.virtuslab"
 //> using publish.name "besom-core"
@@ -20,7 +20,7 @@
 //> using lib "com.outr::scribe-file:3.11.3"
 //> using lib "com.lihaoyi::pprint:0.6.6" // TODO BALEET
 
-//> using options "-java-output-version:8"
+//> using options "-java-output-version:8", "-Ysafe-init"
 
 //#> using options "-Xmax-inlines:64"
 

--- a/core/src/main/scala/besom/types.scala
+++ b/core/src/main/scala/besom/types.scala
@@ -1,8 +1,28 @@
 package besom
 
+import besom.internal.{Decoder, Encoder}
+
 object types:
   // TODO: replace these stubs with proper implementations
-  type PulumiAsset = String
-  type PulumiArchive = String
-  type PulumiAny = spray.json.JsValue
-  type PulumiJson = spray.json.JsValue
+  private object Opaques:
+    opaque type PulumiAsset = String
+    object PulumiAsset:
+      given Encoder[PulumiAsset] = Encoder.stringEncoder
+      given Decoder[PulumiAsset] = Decoder.stringDecoder
+
+    opaque type PulumiArchive = String
+    object PulumiArchive:
+      given Encoder[PulumiArchive] = Encoder.stringEncoder
+      given Decoder[PulumiArchive] = Decoder.stringDecoder
+
+    opaque type PulumiAny = spray.json.JsValue
+    object PulumiAny:
+      given Encoder[PulumiAny] = Encoder.jsonEncoder
+      given Decoder[PulumiAny] = Decoder.jsonDecoder
+
+    opaque type PulumiJson = spray.json.JsValue
+    object PulumiJson:
+      given Encoder[PulumiJson] = Encoder.jsonEncoder
+      given Decoder[PulumiJson] = Decoder.jsonDecoder
+
+  export Opaques.*

--- a/core/src/test/scala/besom/internal/ContextTest.scala
+++ b/core/src/test/scala/besom/internal/ContextTest.scala
@@ -3,10 +3,18 @@ package besom.internal
 import RunResult.{given, *}
 import com.google.protobuf.struct.*
 
-enum TestEnum derives Encoder:
-  case Test1
-  case AnotherTest
-  case `weird-test`
+sealed abstract class TestEnum(val name: String, val value: String) extends besom.internal.StringEnum
+
+object TestEnum extends besom.internal.EnumCompanion[TestEnum]("TestEnum"):
+  object Test1 extends TestEnum("Test1", "Test1 value")
+  object AnotherTest extends TestEnum("AnotherTest", "AnotherTest value")
+  object `weird-test` extends TestEnum("weird-test", "weird-test value")
+
+  override val allInstances: Seq[TestEnum] = Seq(
+    Test1,
+    AnotherTest,
+    `weird-test`
+  )
 
 case class PlainCaseClass(data: String, moreData: Int) derives Encoder
 case class TestArgs(a: Output[String], b: Output[PlainCaseClass]) derives ArgsEncoder
@@ -67,7 +75,7 @@ class ContextTest extends munit.FunSuite:
   test("quick dirty Encoder test - enums") {
     given Context = DummyContext().unsafeRunSync()
 
-    val (res, value) = encode(
+    val (res, value) = encode[TestEnum](
       TestEnum.`weird-test`
     )
 

--- a/core/src/test/scala/besom/internal/DecoderTest.scala
+++ b/core/src/test/scala/besom/internal/DecoderTest.scala
@@ -15,9 +15,15 @@ object DecoderTest:
     optSome: Option[String]
   ) derives Decoder
 
-  enum TestEnum derives Decoder:
-    case A
-    case B
+
+  sealed abstract class TestEnum(val name: String, val value: String) extends besom.internal.StringEnum
+
+  object TestEnum extends besom.internal.EnumCompanion[TestEnum]("TestEnum"):
+    object A extends TestEnum("A", "A value")
+    object B extends TestEnum("B", "B value")
+
+    override val allInstances: Seq[TestEnum] = Seq(A, B)
+
 
 class DecoderTest extends munit.FunSuite:
   import DecoderTest.*

--- a/experimental/project.scala
+++ b/experimental/project.scala
@@ -1,2 +1,2 @@
-//> using scala "3.2.2"
+//> using scala "3.3.0"
 //> using lib "org.virtuslab::besom-core:0.0.1-SNAPSHOT"


### PR DESCRIPTION
* AWS codegen tweaks:
  * Mangle names of properties and classes if needed
  * Allow ignoring (not compiling) provider's troublesome modules
  * Represent pulumi enums as sealed classes rather than scala 3 enums
* Log codegen warnings to a file
* Bump scala to 3.3.0
* Add scala-compose config