### PR TITLE
Better optional `Output`s follow-up

### DIFF
--- a/codegen/src/CodeGen.scala
+++ b/codegen/src/CodeGen.scala
@@ -10,8 +10,8 @@ import besom.codegen.Utils._
 
 class CodeGen(implicit providerConfig: Config.ProviderConfig, typeMapper: TypeMapper, logger: Logger) {
   val commonImportedIdentifiers = Seq(
-    "besom.Output",
-    "besom.Context"
+    "besom.types.Output",
+    "besom.types.Context"
   )
 
   def sourcesFromPulumiPackage(pulumiPackage: PulumiPackage, besomVersion: String): Seq[SourceFile] = {
@@ -158,13 +158,13 @@ class CodeGen(implicit providerConfig: Config.ProviderConfig, typeMapper: TypeMa
     val argsClassName = Type.Name(argsClassCoordinates.className).syntax
     
     val baseFileImports = makeImportStatements(commonImportedIdentifiers ++ Seq(
-      "besom.Decoder"
+      "besom.types.Decoder"
     ))
 
     val argsFileImports = makeImportStatements(commonImportedIdentifiers ++ Seq(
-      "besom.Input",
-      "besom.Encoder",
-      "besom.ArgsEncoder"
+      "besom.types.Input",
+      "besom.types.Encoder",
+      "besom.types.ArgsEncoder"
     ))
 
     val objectProperties = {
@@ -571,6 +571,7 @@ class CodeGen(implicit providerConfig: Config.ProviderConfig, typeMapper: TypeMa
     "synchronized",
     "wait",
     "asInstanceOf",
+    "clone",
     "equals",
     "getClass",
     "hashCode",

--- a/codegen/src/TypeMapper.scala
+++ b/codegen/src/TypeMapper.scala
@@ -89,8 +89,12 @@ class TypeMapper(
         objectClassCoordinates
       } else {
         (resourceClassCoordinates, objectClassCoordinates) match {
-          case (Some(coordinates), None) => Some(coordinates)
-          case (None, Some(coordinates)) => Some(coordinates)
+          case (Some(coordinates), None) =>
+            logger.warn(s"Assuming a '/resources/` prefix for type URI ${typeUri}")
+            Some(coordinates)
+          case (None, Some(coordinates)) =>
+            logger.warn(s"Assuming a '/types/` prefix for type URI ${typeUri}")
+            Some(coordinates)
           case (None, None) => None
           case _ => throw new Exception(s"Type URI ${typeUri} can refer to both a resource or an object type")
         }


### PR DESCRIPTION
* Improve type mapping heuristic warnings
* Escape `clone` as property name in codegen (fixes codegen for GCP)
* Use runtime agnostic `besom.types.*` classes in codegen