### PR TITLE
Use shorter scala-cli install one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ using the Scala programming language. Scala support is currently in **Public Bet
    [installation instructions](https://scala-cli.virtuslab.org/install) for additional installation options):
 
     ```bash
-    curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh
+    curl -sSLf https://scala-cli.virtuslab.org/get | sh
     ```
 
 3. **Install Scala Language Plugin in Pulumi**:

--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -21,7 +21,7 @@ To start your adventure with infrastructure-as-code with Scala follow these step
    [installation instructions](https://scala-cli.virtuslab.org/install) for additional installation options):
 
     ```bash
-    curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh
+    curl -sSLf https://scala-cli.virtuslab.org/get | sh
     ```
 
 3. **Install Scala Language Plugin in Pulumi**:


### PR DESCRIPTION
Thanks to scala CLI team we have now a pretty install url :)

Fixed here:
https://github.com/VirtusLab/scala-cli/issues/2427

As we say in Poland: "a small thing but it makes me happy"