### PR TITLE
Codegen - deal with broken schemas

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -351,6 +351,14 @@ clean-test-markdown:
 	rm -rf target/mdoc-website
 
 ####################
+# Troubleshooting
+####################
+
+power-wash: clean-all
+	git clean -i -d -x
+	killall -9 java
+
+####################
 # Demo
 ####################
 

--- a/codegen/src/CodeGen.scala
+++ b/codegen/src/CodeGen.scala
@@ -105,7 +105,7 @@ class CodeGen(implicit providerConfig: Config.ProviderConfig, typeMapper: TypeMa
     sourceFilesForResource(
       typeCoordinates = typeCoordinates,
       resourceDefinition = pulumiPackage.provider,
-      typeToken = s"pulumi:provider:${pulumiPackage.name}",
+      typeToken = TypeToken("pulumi", "provider", pulumiPackage.name),
       isProvider = true
     )
   }
@@ -328,7 +328,7 @@ class CodeGen(implicit providerConfig: Config.ProviderConfig, typeMapper: TypeMa
           sourceFilesForResource(
             typeCoordinates = typeMapper.parseTypeToken(typeToken, moduleToPackageParts, providerToPackageParts),
             resourceDefinition = resourceDefinition,
-            typeToken = typeToken,
+            typeToken = TypeToken(typeToken),
             isProvider = false
           )
       }
@@ -339,7 +339,7 @@ class CodeGen(implicit providerConfig: Config.ProviderConfig, typeMapper: TypeMa
   def sourceFilesForResource(
     typeCoordinates: PulumiTypeCoordinates,
     resourceDefinition: ResourceDefinition,
-    typeToken: String,
+    typeToken: TypeToken,
     isProvider: Boolean
   ): Seq[SourceFile] = {
     val baseClassCoordinates = typeCoordinates.asResourceClass(asArgsType = false)
@@ -466,7 +466,7 @@ class CodeGen(implicit providerConfig: Config.ProviderConfig, typeMapper: TypeMa
 
     // the type has to match Pulumi's resource type schema, e.g. kubernetes:core/v1:Pod
     // please make sure, it contains 'index' instead of empty module part if needed
-    val typ = Lit.String(typeToken)
+    val typ = Lit.String(typeToken.asString)
 
     val baseCompanion =
       if (hasOutputExtensions) {

--- a/codegen/src/PulumiTypeCoordinates.scala
+++ b/codegen/src/PulumiTypeCoordinates.scala
@@ -42,22 +42,27 @@ object PulumiTypeCoordinates {
 
   // This naïvely tries to avoid the limitation on the length of file paths in a file system
   // TODO: truncated file names with a suffix might still potentially clash with each other
-  private def uniquelyTruncateTypeName(name: String)(implicit logger: Logger) =
-    if (name.length <= maxNameLength) {
-      name
-    } else {
-      val preservedPrefix   = name.substring(0, maxNameLength)
-      val removedSuffixHash = Math.abs(name.substring(maxNameLength, name.length).hashCode)
-      val truncatedName     = s"${preservedPrefix}__${removedSuffixHash}__"
+  private def uniquelyTruncateTypeName(name: String) = {
+    val preservedPrefix   = name.substring(0, maxNameLength)
+    val removedSuffixHash = Math.abs(name.substring(maxNameLength, name.length).hashCode)
+    val truncatedName     = s"${preservedPrefix}__${removedSuffixHash}__"
 
-      truncatedName
-    }
+    truncatedName
+  }
 
   private def mangleTypeName(name: String)(implicit logger: Logger) = {
-    val mangledName = capitalize(uniquelyTruncateTypeName(name))
-    if (mangledName != name)
-      logger.warn(s"Mangled type name '$name' as '$mangledName'")
-    mangledName
+    val truncated = if (name.length <= maxNameLength) {
+      name
+    } else {
+      val truncated = uniquelyTruncateTypeName(name)
+      logger.warn(s"Mangled type name '$name' as '$truncated' (truncated)")
+      truncated
+    }
+    val capitalized = capitalize(truncated)
+    if (capitalized != truncated)
+      logger.debug(s"Mangled type name '$name' as '$capitalized' (capitalized)")
+
+    capitalized
   }
 
   @throws[PulumiTypeCoordinatesError]("if 'typeName' is empty")

--- a/codegen/src/TypeMapper.scala
+++ b/codegen/src/TypeMapper.scala
@@ -36,8 +36,6 @@ object TypeToken {
       `type` = `type`
     )
   }
-
-  def unapply(t: TypeToken): Option[(String, String, String)] = Some((t.provider, t.module, t.`type`))
 }
 
 class TypeMapper(

--- a/codegen/src/TypeMapper.scala
+++ b/codegen/src/TypeMapper.scala
@@ -5,9 +5,7 @@ import scala.meta._
 import scala.meta.dialects.Scala33
 import besom.codegen.metaschema._
 
-import scala.annotation.unused
-
-case class TypeToken private (provider: String, module: String, `type`: String, @unused dummy: Boolean = false) {
+case class TypeToken private (provider: String, module: String, `type`: String) {
   def asString: String = s"${provider}:${module}:${`type`}"
 }
 

--- a/codegen/src/TypeMapper.test.scala
+++ b/codegen/src/TypeMapper.test.scala
@@ -1,5 +1,7 @@
 package besom.codegen
 
+import besom.codegen.Config.ProviderConfig
+
 //noinspection ScalaFileName,TypeAnnotation
 class TypeMapperTest extends munit.FunSuite {
   import besom.codegen.Utils.PulumiPackageOps
@@ -54,31 +56,8 @@ class TypeMapperTest extends munit.FunSuite {
 
   val tests = List(
     Data(
-      providerName = "example",
-      typeToken = "example::SomeType"
-    )(
-      ResourceClassExpectations(
-        fullPackageName = "besom.api.example",
-        fullyQualifiedTypeRef = "besom.api.example.SomeType",
-        filePath = "src/index/SomeType.scala"
-      )
-    ),
-    Data(
       providerName = "digitalocean",
       typeToken = "digitalocean:index:Domain",
-      meta = Meta(
-        moduleFormat = "(.*)(?:/[^/]*)"
-      )
-    )(
-      ResourceClassExpectations(
-        fullPackageName = "besom.api.digitalocean",
-        fullyQualifiedTypeRef = "besom.api.digitalocean.Domain",
-        filePath = "src/index/Domain.scala"
-      )
-    ),
-    Data(
-      providerName = "digitalocean",
-      typeToken = "digitalocean::Domain",
       meta = Meta(
         moduleFormat = "(.*)(?:/[^/]*)"
       )
@@ -160,7 +139,7 @@ class TypeMapperTest extends munit.FunSuite {
 
   tests.foreach { data =>
     test(s"Type: ${data.typeToken}".withTags(data.tags)) {
-      implicit val providerConfig: Config.ProviderConfig = Config.providersConfigs(data.providerName)
+      implicit val providerConfig: ProviderConfig = Config.providersConfigs(data.providerName)
 
       val schemaProvider = new DownloadingSchemaProvider(schemaCacheDirPath = schemaDir)
 
@@ -231,7 +210,7 @@ class AsScalaTypeTest extends munit.FunSuite {
 
   tests.foreach { data =>
     test(s"${data.`type`.getClass.getSimpleName}".withTags(data.tags)) {
-      implicit val providerConfig: Config.ProviderConfig = Config.providersConfigs(data.providerName)
+      implicit val providerConfig: ProviderConfig = Config.providersConfigs(data.providerName)
 
       val schemaProvider = new DownloadingSchemaProvider(schemaCacheDirPath = schemaDir)
 
@@ -248,3 +227,19 @@ class AsScalaTypeTest extends munit.FunSuite {
   }
 }
 
+//noinspection ScalaFileName,TypeAnnotation
+class TypeTokenTest extends munit.FunSuite {
+  test("must provide string representation") {
+    val t1 = TypeToken("provider", "index", "SomeType")
+    assertEquals(t1.asString, "provider:index:SomeType")
+    val t2 = TypeToken("provider:index:SomeType")
+    assertEquals(t2.asString, "provider:index:SomeType")
+  }
+
+  test("must provide the missing module") {
+    val t1 = TypeToken("provider", "", "SomeType")
+    assertEquals(t1.asString, "provider:index:SomeType")
+    val t2 = TypeToken("provider::SomeType")
+    assertEquals(t2.asString, "provider:index:SomeType")
+  }
+}

--- a/codegen/src/TypeMapper.test.scala
+++ b/codegen/src/TypeMapper.test.scala
@@ -90,6 +90,19 @@ class TypeMapperTest extends munit.FunSuite {
       )
     ),
     Data(
+      providerName = "digitalocean",
+      typeToken = "digitalocean:index/getProjectsProject:getProjectsProject",
+      meta = Meta(
+        moduleFormat = "(.*)(?:/[^/]*)"
+      )
+    )(
+      ResourceClassExpectations(
+        fullPackageName = "besom.api.digitalocean",
+        fullyQualifiedTypeRef = "besom.api.digitalocean.GetProjectsProject",
+        filePath = "src/index/GetProjectsProject.scala"
+      )
+    ),
+    Data(
       providerName = "foo-bar",
       typeToken = "foo-bar:index:TopLevel"
     )(

--- a/codegen/src/Utils.scala
+++ b/codegen/src/Utils.scala
@@ -42,12 +42,13 @@ object Utils {
     private def packageFormatModuleToPackageParts: String => Seq[String] = { module: String =>
       val moduleFormat: Regex = pulumiPackage.meta.moduleFormat.r
       module match {
-        case _ if module == indexModuleName || module.isEmpty => Seq(module)
+        case _ if module.isEmpty =>
+          throw TypeMapperError("Module cannot be empty")
+        case _ if module == indexModuleName => Seq(indexModuleName)
         case moduleFormat(name) => languageModuleToPackageParts(name)
         case _ =>
           throw TypeMapperError(
-            s"Cannot parse module portion '$module' with " +
-              s"moduleFormat: $moduleFormat"
+            s"Cannot parse module portion '$module' with moduleFormat: $moduleFormat"
           )
       }
     }

--- a/integration-tests/CodegenTests.test.scala
+++ b/integration-tests/CodegenTests.test.scala
@@ -64,7 +64,7 @@ class CodegenTests extends munit.FunSuite {
     "cyclic-types",
     "plain-and-default",
     "different-package-name-conflict",
-    "azure-native-nested-types",
+    "azure-native-nested-types"
   )
 
   val tests =


### PR DESCRIPTION
- [Codegen disallows empty module in Pulumi type](https://github.com/VirtusLab/besom/commit/5b13046fb78e56d726c6f34e574019190d31da64)
- [Add ensureIndexModule to codegen config for optional sanitization](https://github.com/VirtusLab/besom/commit/334208db0e1fd271e64daf62ba6a4c35456eeaa2)
- [Add TypeToken in codegen](https://github.com/VirtusLab/besom/commit/04240276bc816e03c019b239af006bafb1272aee)

other small fixes