### PR TITLE
Test and document Config

### DIFF
--- a/core/src/main/scala/besom/future.scala
+++ b/core/src/main/scala/besom/future.scala
@@ -3,13 +3,40 @@ package besom
 import besom.internal.*
 import scala.concurrent.*
 
+/** A module that provides a runtime for the [[scala.concurrent.Future]] monad.
+  */
 trait FutureMonadModule extends BesomModule:
   override final type Eff[+A] = scala.concurrent.Future[A]
-  given ExecutionContext      = scala.concurrent.ExecutionContext.global
+  given ExecutionContext                 = scala.concurrent.ExecutionContext.global
   protected lazy val rt: Runtime[Future] = FutureRuntime()
 
   implicit val toFutureFuture: Result.ToFuture[Eff] = new Result.ToFuture[Future]:
     def eval[A](fa: => Future[A]): () => Future[A] = () => fa
 
+/** Besom API entry point for the [[scala.concurrent.Future]] monad.
+  *
+  * All Pulumi programs are executed in Besom context [[besom.Context]]
+  *
+  * Most notable methods exposed by [[besom.Pulumi]] are:
+  *   - [[besom.internal.BesomModule.run]] - the Pulumi program function
+  *   - [[besom.internal.BesomSyntax.exports]] - the Pulumi Stack outputs
+  *   - [[besom.internal.BesomSyntax.config]] - configuration and secrets
+  *   - [[besom.internal.BesomSyntax.log]] - all your logging needs
+  *
+  * Inside `Pulumi.run` block you can use all methods without `Pulumi.` prefix. All functions that belong to Besom
+  * program but are defined outside the `Pulumi.run` block should have the following using clause: `(using Context)` or
+  * `(using besom.Context)` using a fully qualified name of the type.
+  *
+  * The hello world example:
+  * {{{
+  * import besom.*
+  *
+  * @main def main = Pulumi.run {
+  *   for
+  *     _ <- log.warn("Nothing's here yet, it's waiting for you to write some code!")
+  *   yield exports()
+  * }
+  * }}}
+  */
 object Pulumi extends FutureMonadModule
-export Pulumi.{ *, given }
+export Pulumi.{*, given}

--- a/core/src/main/scala/besom/internal/Config.scala
+++ b/core/src/main/scala/besom/internal/Config.scala
@@ -1,9 +1,16 @@
 package besom.internal
 
-import besom.internal.logging.BesomLogger
 import besom.util.NonEmptyString
+
 import scala.util.Try
 
+/** Config is a bag of related configuration state. Each bag contains any number of configuration variables, indexed by
+  * simple keys, and each has a name that uniquely identifies it; two bags with different names do not share values for
+  * variables that otherwise share the same key. For example, a bag whose name is `pulumi:foo`, with keys `a`, `b`, and
+  * `c`, is entirely separate from a bag whose name is `pulumi:bar` with the same simple key names. Each key has a fully
+  * qualified names, such as `pulumi:foo:a`, ..., and `pulumi:bar:a`, respectively.
+  */
+//noinspection ScalaWeakerAccess
 class Config private (
   val namespace: NonEmptyString,
   private[internal] val isProjectName: Boolean,
@@ -13,63 +20,194 @@ class Config private (
   private def fullKey(key: NonEmptyString): NonEmptyString = namespace +++ ":" +++ key
 
   private def tryGet(key: NonEmptyString): Option[String] = configMap.get(fullKey(key)) match
-    case sme: Some[?] => sme
+    case sme: Some[?]          => sme
     case None if isProjectName => configMap.get(key)
-    case None => None
+    case None                  => None
 
-  private[besom] def unsafeGet(key: NonEmptyString): Option[String] = tryGet(key)
+  /** This method is unsafe because it will return a secret value as a plain string. This is useful for provider SDKs.
+    * @param key
+    *   the requested configuration key
+    * @return
+    *   the configuration value of the requested type
+    */
+  // noinspection ScalaUnusedSymbol
+  private[besom] def unsafeGet(key: NonEmptyString) = tryGet(key)
 
+  /** This method differs in behavior from other Pulumi SDKs. In other SDKs, if you try to get a config key that is a
+    * secret, you will obtain it (due to https://github.com/pulumi/pulumi/issues/7127 you won't even get a warning). We
+    * choose to do the right thing here and not return the secret value as an unmarked plain string. For provider SDKs
+    * we have the unsafeGet method should it be absolutely necessary in practice. We also return all configs as Outputs
+    * so that we can handle failure in pure, functional way.
+    * @param key
+    *   the requested configuration key
+    * @return
+    *   the configuration value of the requested type
+    */
   private def getRawValue(key: NonEmptyString)(using ctx: Context): Output[Option[String]] =
     if configSecretKeys.contains(key)
-      then Output.secret(tryGet(key))
-      else Output(tryGet(key))
+    then Output.secret(tryGet(key))
+    else Output(tryGet(key))
 
-  private def readConfigValue[A : ConfigValueReader](key: NonEmptyString, rawValue: Output[Option[String]])(using Context): Output[Option[A]] =
+  private def readConfigValue[A: ConfigValueReader](
+    key: NonEmptyString,
+    rawValue: Output[Option[String]]
+  )(using Context): Output[Option[A]] =
     rawValue.flatMap { valueOpt =>
       Output.ofData {
         Result
           .evalEither(
             valueOpt.map(value => summon[ConfigValueReader[A]].read(key = key, rawValue = value)) match
-              case None => Right(None)
+              case None               => Right(None)
               case Some(Right(value)) => Right(Some(value))
-              case Some(Left(error)) => Left(error)
+              case Some(Left(error))  => Left(error)
           )
           .map(OutputData(_))
       }
     }
 
-  def get[A : ConfigValueReader](key: NonEmptyString)(using Context): Output[Option[A]] =
+  /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+    * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @tparam A
+    *   the type of the configuration value
+    * @return
+    *   an optional configuration value of the requested type
+    */
+  def get[A: ConfigValueReader](key: NonEmptyString)(using Context): Output[Option[A]] =
     readConfigValue(key, getRawValue(key))
 
-  def require[A : ConfigValueReader](key: NonEmptyString)(using Context): Output[A] =
+  /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+    * secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @tparam A
+    *   the type of the configuration value
+    * @return
+    *   the configuration value of the requested type or [[ConfigError]]
+    */
+  def require[A: ConfigValueReader](key: NonEmptyString)(using Context): Output[A] = {
+    def secretOption = if configSecretKeys.contains(key) then "[--secret]" else ""
     get[A](key).flatMap { valueOpt =>
       valueOpt match
         case Some(value) => Output(value)
-        case None => Output.fail {
-          val message =
-            s"""|Missing required configuration variable '${key}'
-                |Please set a value using the command `pulumi config set ${key} <value> [--secret]`""".stripMargin
-          new Exception(message)
-        }
+        case None =>
+          Output.fail {
+            ConfigError(
+              s"""|Missing required configuration variable '${key}'
+                  |Please set a value using the command `pulumi config set ${key} <value> $secretOption`""".stripMargin
+            )
+          }
     }
+  }
 
+  /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+    * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   an optional configuration [[String]] value
+    */
   def getString(key: NonEmptyString)(using Context): Output[Option[String]] = get[String](key)
+
+  /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+    * secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   the configuration [[String]] value or [[ConfigError]]
+    */
   def requireString(key: NonEmptyString)(using Context): Output[String] = require[String](key)
-  
+
+  /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+    * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   an optional configuration [[Double]] value
+    */
   def getDouble(key: NonEmptyString)(using Context): Output[Option[Double]] = get[Double](key)
+
+  /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+    * secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   the configuration [[Double]] value or [[ConfigError]]
+    */
   def requireDouble(key: NonEmptyString)(using Context): Output[Double] = require[Double](key)
-  
+
+  /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+    * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   an optional configuration [[Int]] value
+    */
   def getInt(key: NonEmptyString)(using Context): Output[Option[Int]] = get[Int](key)
+
+  /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+    * secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   the configuration [[Int]] value or [[ConfigError]]
+    */
   def requireInt(key: NonEmptyString)(using Context): Output[Int] = require[Int](key)
-  
+
+  /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+    * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   an optional configuration [[Boolean]] value
+    */
   def getBoolean(key: NonEmptyString)(using Context): Output[Option[Boolean]] = get[Boolean](key)
+
+  /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+    * secret, it will be marked internally as such and redacted in console outputs.
+    *
+    * @param key
+    *   the requested configuration key
+    * @param Context
+    *   the Besom context
+    * @return
+    *   the configuration [[Boolean]] value or [[ConfigError]]
+    */
   def requireBoolean(key: NonEmptyString)(using Context): Output[Boolean] = require[Boolean](key)
 
+//noinspection ScalaUnusedSymbol
 object Config:
-  /** CleanKey takes a configuration key, and if it is of the form "(string):config:(string)" removes the ":config:"
-    * portion. Previously, our keys always had the string ":config:" in them, and we'd like to remove it. However, the
+  /** CleanKey takes a configuration key, and if it is of the form `"(string):config:(string)"` removes the `":config:"`
+    * portion. Previously, our keys always had the string `":config:"` in them, and we'd like to remove it. However, the
     * language host needs to continue to set it so we can be compatible with older versions of our packages. Once we
-    * stop supporting older packages, we can change the language host to not add this :config: thing and remove this
+    * stop supporting older packages, we can change the language host to not add this `:config:` thing and remove this
     * function.
     */
   private def cleanKey(key: String): String =
@@ -85,26 +223,33 @@ object Config:
     isProjectName: Boolean,
     configMap: Map[NonEmptyString, String],
     configSecretKeys: Set[NonEmptyString]
-  ): Result[Config] = Result.defer {
-    new Config(
-      namespace = namespace,
-      isProjectName = isProjectName,
-      configMap = configMap.map { case (k, v) =>
-        val cleanedKey = NonEmptyString(cleanKey(k)).getOrElse {
-          throw new Exception(s"The config key ${k} was empty after cleaning")
+  ): Result[Config] =
+    val cleanedConfigMap =
+      Result.evalTry {
+        Try {
+          configMap.map { case (k, v) =>
+            val cleanedKey = NonEmptyString(cleanKey(k)) match {
+              case Some(value) => value
+              case None        => throw CoreError(s"The config key '$k' was empty after cleaning")
+            }
+            (cleanedKey, v)
+          }
         }
-        (cleanedKey, v)
-      },
-      configSecretKeys = configSecretKeys.map(identity)
-    )
-  }
+      }
 
-  import Env.*
-  
+    cleanedConfigMap.map(cm =>
+      new Config(
+        namespace = namespace,
+        isProjectName = isProjectName,
+        configMap = cm,
+        configSecretKeys = configSecretKeys.map(identity)
+      )
+    )
+
   private def apply(namespace: NonEmptyString, isProjectName: Boolean): Result[Config] =
     for
-      configMap        <- Result.evalTry(Env.getConfigMap(EnvConfig))
-      configSecretKeys <- Result.evalTry(Env.getConfigSecretKeys(EnvConfigSecretKeys))
+      configMap        <- Result.evalTry(Env.getConfigMap(Env.EnvConfig))
+      configSecretKeys <- Result.evalTry(Env.getConfigSecretKeys(Env.EnvConfigSecretKeys))
       config           <- Config(namespace, isProjectName, configMap, configSecretKeys)
     yield config
 
@@ -118,31 +263,149 @@ object Config:
   private[internal] def forProject(projectName: NonEmptyString): Result[Config] =
     val cleanedProjectName =
       if projectName.endsWith(":config") then
-        NonEmptyString(projectName.replaceAll(":config$", "")).getOrElse {
-          throw new RuntimeException(s"Invalid project name: $projectName - project name cannot be empty!")
-        }
-      else projectName
-    Config(projectName, isProjectName = true)
+        NonEmptyString(projectName.stripSuffix(":config")) match
+          case Some(value) => Result(value)
+          case None        => Result.fail(ConfigError(s"Project name '$projectName' was empty after cleaning"))
+      else Result.pure(projectName)
+
+    cleanedProjectName.flatMap(name => Config(name, isProjectName = true))
 
   extension (output: Output[Config])
-    def get[A : ConfigValueReader](key: NonEmptyString)(using Context): Output[Option[A]] =
+    /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+      * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @tparam A
+      *   the type of the configuration value
+      * @return
+      *   an optional configuration value of the requested type
+      */
+    def get[A: ConfigValueReader](key: NonEmptyString)(using Context): Output[Option[A]] =
       output.flatMap(_.get[A](key))
-    def require[A : ConfigValueReader](key: NonEmptyString)(using Context): Output[A] =
+
+    /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+      * secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @tparam A
+      *   the type of the configuration value
+      * @return
+      *   the configuration value of the requested type or [[ConfigError]]
+      */
+    def require[A: ConfigValueReader](key: NonEmptyString)(using Context): Output[A] =
       output.flatMap(_.require[A](key))
 
+    /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+      * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   an optional configuration [[String]] value
+      */
     def getString(key: NonEmptyString)(using Context): Output[Option[String]] = output.flatMap(_.getString(key))
+
+    /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+      * secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   the configuration [[String]] value or [[ConfigError]]
+      */
     def requireString(key: NonEmptyString)(using Context): Output[String] = output.flatMap(_.requireString(key))
 
+    /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+      * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   an optional configuration [[Double]] value
+      */
     def getDouble(key: NonEmptyString)(using Context): Output[Option[Double]] = output.flatMap(_.getDouble(key))
+
+    /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+      * secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   the configuration [[Double]] value or [[ConfigError]]
+      */
     def requireDouble(key: NonEmptyString)(using Context): Output[Double] = output.flatMap(_.requireDouble(key))
-    
+
+    /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+      * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   an optional configuration [[Int]] value
+      */
     def getInt(key: NonEmptyString)(using Context): Output[Option[Int]] = output.flatMap(_.getInt(key))
+
+    /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+      * secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   the configuration [[Int]] value or [[ConfigError]]
+      */
     def requireInt(key: NonEmptyString)(using Context): Output[Int] = output.flatMap(_.requireInt(key))
 
+    /** Loads an optional configuration or secret value by its key, or returns [[None]] if it doesn't exist. If the
+      * configuration value is a secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   an optional configuration [[Boolean]] value
+      */
     def getBoolean(key: NonEmptyString)(using Context): Output[Option[Boolean]] = output.flatMap(_.getBoolean(key))
+
+    /** Loads a configuration or secret value by its key, or throws if it doesn't exist. If the configuration value is a
+      * secret, it will be marked internally as such and redacted in console outputs.
+      *
+      * @param key
+      *   the requested configuration key
+      * @param Context
+      *   the Besom context
+      * @return
+      *   the configuration [[Boolean]] value or [[ConfigError]]
+      */
     def requireBoolean(key: NonEmptyString)(using Context): Output[Boolean] = output.flatMap(_.requireBoolean(key))
 
 trait ConfigFactory:
+  /** Creates a new Config with the given namespace.
+    * @param namespace
+    *   the configuration bag’s logical name that uniquely identifies it.
+    * @param Context
+    *   the Besom context.
+    * @return
+    *   a new Config with the given namespace.
+    */
   def apply(namespace: NonEmptyString)(using Context): Output[Config] =
     val projectConfig = summon[Context].config
     Output(Config.forNamespace(namespace, projectConfig.configMap, projectConfig.configSecretKeys))

--- a/core/src/main/scala/besom/internal/ConfigValueReader.scala
+++ b/core/src/main/scala/besom/internal/ConfigValueReader.scala
@@ -7,20 +7,20 @@ trait ConfigValueReader[A]:
 
 object ConfigValueReader:
   given stringReader: ConfigValueReader[String] with
-    override def read(key: String, rawValue: String) =
+    override def read(key: String, rawValue: String): Either[Exception, String] =
       Right(rawValue)
   given doubleReader: ConfigValueReader[Double] with
-    override def read(key: String, rawValue: String) =
+    override def read(key: String, rawValue: String): Either[Exception, Double] =
       Try(rawValue.toDouble).toEither.left.map(_ =>
         RuntimeException(s"Config value $key is not a valid double: $rawValue")
       )
   given intReader: ConfigValueReader[Int] with
-    override def read(key: String, rawValue: String) =
+    override def read(key: String, rawValue: String): Either[Exception, Int] =
       Try(rawValue.toInt).toEither.left.map(_ =>
         RuntimeException(s"Config value $key is not a valid int: $rawValue")
       )
   given booleanReader: ConfigValueReader[Boolean] with
-    override def read(key: String, rawValue: String) =
+    override def read(key: String, rawValue: String): Either[Exception, Boolean] =
       Try(rawValue.toBoolean).toEither.left.map(_ =>
         RuntimeException(s"Config value $key is not a valid boolean: $rawValue")
       )

--- a/core/src/main/scala/besom/internal/Env.scala
+++ b/core/src/main/scala/besom/internal/Env.scala
@@ -3,6 +3,7 @@ package besom.internal
 import besom.util.NonEmptyString
 import scala.util.Try
 
+//noinspection TypeAnnotation
 object Env:
   // LB: copied verbatim from pulumi-go :P
 

--- a/core/src/main/scala/besom/internal/Resource.scala
+++ b/core/src/main/scala/besom/internal/Resource.scala
@@ -8,13 +8,21 @@ import scala.deriving.Mirror
 import scala.annotation.implicitNotFound
 import besom.util.*
 
+/** An abstract representation of a Pulumi resource. It is used to register resources with the Pulumi engine.
+  */
 sealed trait Resource:
+  /** @return
+    *   the URN of the resource
+    */
   def urn: Output[URN]
   private[internal] def isCustom: Boolean = this match
     case _: CustomResource => true
     case _                 => false
 
 trait CustomResource extends Resource:
+  /** @return
+    *   the [[ResourceId]] of the resource
+    */
   def id: Output[ResourceId]
 
 trait ComponentResource(using
@@ -23,6 +31,9 @@ trait ComponentResource(using
   )
   base: ComponentBase
 ) extends Resource:
+  /** @return
+    *   the URN of the resource
+    */
   override def urn: Output[URN] = base.urn
 
 trait ProviderResource extends CustomResource:

--- a/core/src/main/scala/besom/internal/errors.scala
+++ b/core/src/main/scala/besom/internal/errors.scala
@@ -1,0 +1,23 @@
+package besom.internal
+
+@SerialVersionUID(1L)
+sealed abstract class BaseCoreError(message: Option[String], cause: Option[Throwable])
+    extends Exception(message.orElse(cause.map(_.toString)).orNull, cause.orNull)
+    with Product
+    with Serializable
+
+@SerialVersionUID(1L)
+case class CoreError(message: Option[String], cause: Option[Throwable]) extends BaseCoreError(message, cause)
+object CoreError {
+  def apply(message: String)                   = new CoreError(Some(message), None)
+  def apply(message: String, cause: Throwable) = new CoreError(Some(message), Some(cause))
+  def apply(cause: Throwable)                  = new CoreError(None, Some(cause))
+}
+
+@SerialVersionUID(1L)
+case class ConfigError(message: Option[String], cause: Option[Throwable]) extends BaseCoreError(message, cause)
+object ConfigError {
+  def apply(message: String)                   = new ConfigError(Some(message), None)
+  def apply(message: String, cause: Throwable) = new ConfigError(Some(message), Some(cause))
+  def apply(cause: Throwable)                  = new ConfigError(None, Some(cause))
+}

--- a/core/src/main/scala/besom/util/NonEmptyString.scala
+++ b/core/src/main/scala/besom/util/NonEmptyString.scala
@@ -3,20 +3,42 @@ package besom.util
 import scala.quoted.*
 import scala.language.implicitConversions
 
+/**
+ * A [[String]] that is not empty or blank.
+ */
 opaque type NonEmptyString <: String = String
 
+/**
+ * A [[String]] that is not empty or blank.
+ */
 object NonEmptyString:
+  /** @param s
+   * a [[String]] to be converted to a [[NonEmptyString]].
+   * @return
+   * an optional [[NonEmptyString]] if the given [[String]] is not empty or blank, otherwise [[None]].
+   */
   def apply(s: String): Option[NonEmptyString] =
     if s.isBlank then None else Some(s)
 
   given nonEmptyStringOps: {} with
     extension (nes: NonEmptyString)
+      /** Concatenates this [[NonEmptyString]] with the given [[String]].
+        */
       inline def +++(other: String): NonEmptyString = nes + other
-      inline def asString: String                   = nes
 
+      /** @return
+        *   this [[NonEmptyString]] as a [[String]].
+        */
+      inline def asString: String = nes
+
+  /** @param s
+   * a [[String]] to be converted to a [[NonEmptyString]].
+   * @return
+   * a [[NonEmptyString]] if the given [[String]] is not empty or blank.
+   */
   inline def from(inline s: String): NonEmptyString = ${ fromImpl('s) }
 
-  def fromImpl(expr: Expr[String])(using quotes: Quotes): Expr[NonEmptyString] =
+  private def fromImpl(expr: Expr[String])(using quotes: Quotes): Expr[NonEmptyString] =
     import quotes.reflect.*
 
     expr match
@@ -59,8 +81,21 @@ object NonEmptyString:
   implicit inline def str2NonEmptyString(inline s: String): NonEmptyString = NonEmptyString.from(s)
 
   extension (s: String)
+    /** Returns `true` if the `String` is empty or contains only "white space" characters, otherwise `false`.
+      */
     private def isBlank = s.trim.isEmpty
 
 trait NonEmptyStringFactory:
+  /** @param s
+    *   a [[String]] to be converted to a [[NonEmptyString]].
+    * @return
+    *   an optional [[NonEmptyString]] if the given [[String]] is not empty or blank, otherwise [[None]].
+    */
   def apply(s: String): Option[NonEmptyString] = NonEmptyString(s)
-  inline def from(s: String): NonEmptyString   = NonEmptyString.from(s)
+
+  /** @param s
+    *   a [[String]] to be converted to a [[NonEmptyString]].
+    * @return
+    *   a [[NonEmptyString]] if the given [[String]] is not empty or blank.
+    */
+  inline def from(s: String): NonEmptyString = NonEmptyString.from(s)

--- a/core/src/test/scala/besom/internal/ConfigTest.scala
+++ b/core/src/test/scala/besom/internal/ConfigTest.scala
@@ -4,12 +4,11 @@ import besom.*
 import RunResult.{given, *}
 
 class ConfigTest extends munit.FunSuite {
-  // def testConfig[A](testName: String)(configMap: Map[NonEmptyString, String], configSecretKeys: Set[NonEmptyString])(assertion: Context ?=> Unit): Unit =
+
   def testConfig[A](testName: String)(configMap: Map[String, String], configSecretKeys: Set[NonEmptyString])(assertion: Context ?=> Unit): Unit =
     val nonEmptyKeyConfigMap = configMap.map{ (key, value) => NonEmptyString(key).get -> value }
     given Context = DummyContext(configMap = nonEmptyKeyConfigMap, configSecretKeys = configSecretKeys).unsafeRunSync()
     test(testName)(assertion)
-
 
   def testConfig[A](testName: String)(configMap: Map[String, String], configSecretKeys: Set[NonEmptyString], tested: Context ?=> Output[A], expected: OutputData[A]): Unit =
     testConfig[A](testName)(configMap, configSecretKeys) {
@@ -23,7 +22,6 @@ class ConfigTest extends munit.FunSuite {
       val message = exception.getMessage
       assert(checkErrorMessage(clue(message)))
     }
-
 
   testConfig("get missing key")(
     configMap = Map.empty,
@@ -87,4 +85,39 @@ class ConfigTest extends munit.FunSuite {
     tested = config.getString("foo"),
     expected = OutputData(Some("abc"), isSecret = false)
   )
+
+  testConfig("get string-namespaced")(
+    configMap = Map("foo" -> "abc", "qux:foo" -> "def"),
+    configSecretKeys = Set.empty
+  ) {
+    val outputData = config.getString("qux:foo").getData.unsafeRunSync()
+    clue(outputData)
+    assertEquals(outputData, OutputData(Some("def"), isSecret = false))
+  }
+
+  testConfig("getOrElse")(
+    configMap = Map.empty,
+    configSecretKeys = Set.empty,
+  ) {
+    val outputData1 = config.getString("foo").getOrElse("bar").getData.unsafeRunSync()
+    clue(outputData1)
+    assertEquals(outputData1, OutputData("bar", isSecret = false))
+
+    val outputData2 = config.getString("foo").getOrElse(Output("bar")).getData.unsafeRunSync()
+    clue(outputData2)
+    assertEquals(outputData2, OutputData("bar", isSecret = false))
+  }
+
+  testConfig("orElse")(
+    configMap = Map.empty,
+    configSecretKeys = Set.empty
+  ) {
+    val outputData1 = config.getString("foo").orElse(Some("bar")).getData.unsafeRunSync()
+    clue(outputData1)
+    assertEquals(outputData1, OutputData(Some("bar"), isSecret = false))
+
+    val outputData2 = config.getString("foo").orElse(Output(Some("bar"))).getData.unsafeRunSync()
+    clue(outputData2)
+    assertEquals(outputData2, OutputData(Some("bar"), isSecret = false))
+  }
 }

--- a/integration-tests/integration.scala
+++ b/integration-tests/integration.scala
@@ -66,6 +66,27 @@ object pulumi {
     additional
   )
 
+  def config(stackName: String, additional: os.Shellable*) = pproc(
+    "pulumi",
+    "--non-interactive",
+    "config",
+    "--stack",
+    stackName,
+    "set",
+    additional
+  )
+
+  def secret(stackName: String, additional: os.Shellable*) = pproc(
+    "pulumi",
+    "--non-interactive",
+    "config",
+    "--stack",
+    stackName,
+    "set",
+    "--secret",
+    additional
+  )
+
   def installScalaPlugin() =
     pproc(
       "pulumi",

--- a/integration-tests/resources/config-example/Main.scala
+++ b/integration-tests/resources/config-example/Main.scala
@@ -1,0 +1,14 @@
+import besom.*
+
+//noinspection UnitMethodIsParameterless,TypeAnnotation
+@main def main = Pulumi.run {
+  for
+    name <- config.requireString("name")
+    hush <- config.requireString("hush")
+    notThere <- config.get[String]("notThere").getOrElse("default value")
+  yield exports(
+    name = name,
+    hush = hush,
+    notThere = notThere
+  )
+}

--- a/integration-tests/resources/config-example/Pulumi.yaml
+++ b/integration-tests/resources/config-example/Pulumi.yaml
@@ -1,5 +1,5 @@
-name: logging-besom-test
-description: Besom logging test
+name: config-besom-test
+description: Besom config test
 runtime:
   name: scala
   options:

--- a/integration-tests/resources/config-example/project.scala
+++ b/integration-tests/resources/config-example/project.scala
@@ -1,0 +1,4 @@
+//> using scala 3.3.1
+//> using options -java-output-version:11 -Werror -Wunused:all -Wvalue-discard -Wnonunit-statement
+//> using plugin org.virtuslab::besom-compiler-plugin:0.1.1-SNAPSHOT
+//> using dep org.virtuslab::besom-core:0.1.1-SNAPSHOT


### PR DESCRIPTION
- finishing touches on #287 to improve `Config` ergonomy
- add `Output[Option[A]].orElse` and `.getOrElse`
- add unit tests, integration tests, scaladoc

Fixes #204
Fixes #205