### PR TITLE
fixes #228

### DIFF
--- a/core/src/main/scala/besom/internal/BesomModule.scala
+++ b/core/src/main/scala/besom/internal/BesomModule.scala
@@ -23,7 +23,7 @@ trait EffectBesomModule extends BesomSyntax:
         featureSupport <- FeatureSupport(monitor)
         _              <- logger.trace(s"Environment:\n${sys.env.toSeq.sortBy(_._1).map((k, v) => s"$k: $v").mkString("\n")}")
         _              <- logger.debug(s"Resolved feature support, spawning context and executing user program.")
-        ctx            <- Result.resource(Context(runInfo, taskTracker, monitor, engine, logger, featureSupport, config))(_.close())
+        ctx            <- Context(runInfo, taskTracker, monitor, engine, logger, featureSupport, config)
         userOutputs    <- program(using ctx).map(_.toResult).getValueOrElse(Result.pure(Struct()))
         _              <- Stack.registerStackOutputs(runInfo, userOutputs)(using ctx)
         _              <- ctx.waitForAllTasks
@@ -33,10 +33,10 @@ trait EffectBesomModule extends BesomSyntax:
     rt.unsafeRunSync(everything.run(using rt)) match
       case Left(err) =>
         throw err
-      case Right(_)  =>
+      case Right(_) =>
         sys.exit(0)
 
 trait BesomModule extends EffectBesomModule {
-  export besom.types.{ *, given }
-  export besom.util.interpolator.{ *, given }
+  export besom.types.{*, given}
+  export besom.util.interpolator.{*, given}
 }

--- a/core/src/main/scala/besom/internal/Context.scala
+++ b/core/src/main/scala/besom/internal/Context.scala
@@ -69,8 +69,6 @@ trait Context extends TaskTracker:
     opts: InvokeOptions
   )(using Context): Output[R]
 
-  private[besom] def close(): Result[Unit]
-
 class ComponentContext(private val globalContext: Context, private val componentURN: Result[URN]) extends Context:
   export globalContext.{getParentURN => _, *}
 
@@ -153,12 +151,6 @@ class ContextImpl(
     BesomMDC(Key.LabelKey, Label.fromNameAndType(name, typ)) {
       ResourceOps().registerResourceOutputsInternal(urnResult, outputs)
     }
-
-  override private[besom] def close(): Result[Unit] =
-    for
-      _ <- monitor.close()
-      _ <- engine.close()
-    yield ()
 
   private[besom] def readOrRegisterResource[R <: Resource: ResourceDecoder, A: ArgsEncoder](
     typ: ResourceType,


### PR DESCRIPTION
 Context was closing gRPC due to older implementation and therefore breaking the ordering guarantees by Result.resource.