### PR TITLE
Expose Pulumi organisation information

### DIFF
--- a/core/src/main/scala/besom/internal/BesomSyntax.scala
+++ b/core/src/main/scala/besom/internal/BesomSyntax.scala
@@ -21,6 +21,12 @@ trait BesomSyntax:
   def urn(using ctx: Context): Output[URN] =
     Output.ofData(ctx.getParentURN.map(OutputData(_)))
 
+  /**
+   * @param ctx the Besom context
+   * @return the organization of the current stack.
+   */
+  def organization(using ctx: Context): Option[NonEmptyString] = ctx.organization
+
   val exports: Export.type = Export
 
   def component[A <: ComponentResource & Product: RegistersOutputs: Typeable](name: NonEmptyString, typ: ResourceType)(

--- a/core/src/main/scala/besom/internal/Context.scala
+++ b/core/src/main/scala/besom/internal/Context.scala
@@ -26,7 +26,7 @@ trait Context extends TaskTracker:
   private[besom] def monitor: Monitor
   private[besom] def getParentURN: Result[URN]
   private[besom] def config: Config
-
+  private[besom] def organization: Option[NonEmptyString]
   private[besom] def isDryRun: Boolean
   private[besom] def logger: BesomLogger
 
@@ -92,6 +92,8 @@ class ContextImpl(
   export taskTracker.{registerTask, waitForAllTasks, fail}
 
   override private[besom] def isDryRun: Boolean = runInfo.dryRun
+  
+  override private[besom] def organization: Option[NonEmptyString] = runInfo.organization
 
   override private[besom] def getParentURN: Result[URN] =
     stackPromise.get.flatMap(_.urn.getData).map(_.getValue).flatMap {

--- a/core/src/main/scala/besom/internal/Env.scala
+++ b/core/src/main/scala/besom/internal/Env.scala
@@ -10,6 +10,8 @@ object Env:
   private[internal] final val EnvProject = "PULUMI_PROJECT"
   // EnvStack is the envvar used to read the current Pulumi stack name.
   private[internal] final val EnvStack = "PULUMI_STACK"
+  // EnvOrganization is the envvar used to read the current Pulumi organization name.
+  private[internal] final val EnvOrganization = "PULUMI_ORGANIZATION"
   // EnvConfig is the envvar used to read the current Pulumi configuration variables.
   private[internal] final val EnvConfig = "PULUMI_CONFIG"
   // EnvConfigSecretKeys is the envvar used to read the current Pulumi configuration keys that are secrets.
@@ -61,6 +63,7 @@ object Env:
   lazy val traceRunToFile  = getMaybe(EnvEnableTraceLoggingToFile).map(isTruthy).getOrElse(false)
   lazy val project         = getOrFail(EnvProject)
   lazy val stack           = getOrFail(EnvStack)
+  lazy val organization    = getMaybe(EnvOrganization)
   lazy val acceptResources = getMaybe(EnvDisableResourceReferences).map(isNotTruthy(_)).getOrElse(true)
   lazy val parallel        = getOrFail(EnvParallel).toInt
   lazy val dryRun          = getOrFail(EnvDryRun).toBoolean

--- a/core/src/main/scala/besom/internal/RunInfo.scala
+++ b/core/src/main/scala/besom/internal/RunInfo.scala
@@ -6,6 +6,7 @@ import scala.util.Try
 import besom.util.*
 
 case class RunInfo(
+  organization: Option[NonEmptyString],
   project: NonEmptyString,
   stack: NonEmptyString,
   acceptResources: Boolean,
@@ -24,6 +25,7 @@ object RunInfo:
         RunInfo(
           project = Env.project,
           stack = Env.stack,
+          organization = Env.organization,
           acceptResources = Env.acceptResources,
           parallel = Env.parallel, // TODO we don't use this, should we?
           dryRun = Env.dryRun,

--- a/core/src/test/scala/besom/internal/DummyContext.scala
+++ b/core/src/test/scala/besom/internal/DummyContext.scala
@@ -9,7 +9,7 @@ import besom.NonEmptyString
 import besom.internal.logging.BesomLogger
 
 object DummyContext:
-  val dummyRunInfo        = RunInfo("test-project", "test-stack", true, 4, false, "dummy", "dummy")
+  val dummyRunInfo        = RunInfo(Some("test-organization"), "test-project", "test-stack", true, 4, false, "dummy", "dummy")
   val dummyFeatureSupport = FeatureSupport(true, true, true, true)
   val dummyMonitor = new Monitor:
     def call(callRequest: CallRequest): Result[CallResponse]                                                  = ???


### PR DESCRIPTION
Ported from Go SDK
https://github.com/pulumi/pulumi/blob/master/sdk/go/pulumi/context.go#L221

The organization in Stack is explained in couple places:
- https://www.pulumi.com/docs/concepts/stack/#create-stack
- https://www.pulumi.com/docs/concepts/stack/#stackreferences

Alternatively, to not pollute the context, we could make this a part of stack name, like we did with the URN, WDYT?