### PR TITLE
Update codegen - normalize type names, fix methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,6 +315,9 @@ runtime:
 - `PULUMI_ENABLE_TRACE_LOGGING_TO_FILE` - for enabling Besom trace logging to file
 - `PULUMI_DEBUG_COMMANDS=1` - for activating hidden debugging Pulumi CLI commands
 - `TF_LOG=TRACE` - for debugging Terraform-based provider
+- `PULUMI_SKIP_UPDATE_CHECK=true` - to skip Pulumi update check
+
+More environment variables can be found in [Pulumi documentation](https://www.pulumi.com/docs/cli/environment-variables/).
 
 #### Tracing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,9 +338,34 @@ rm pulumi.rb
 
 ### Compilation issues
 
+To clean the builds:
+```bash
+just clean-all
+```
+
+If a deep cleaning needed:
+```bash
+just power-wash
+````
+
 To restart `bloop` compilation server:
 ```bash
 scala-cli bloop exit
+```
+
+To set `bloop` verbosity:
+```bash
+scala-cli setup-ide -v -v -v .
+```
+
+To use a nightly version of Scala compiler:
+```bash
+scala-cli compile -S 3.nightly .
+```
+
+To increase Scala compiler verbosity:
+```bash
+scala-cli compile --javac-opt=-verbose .
 ```
 
 ## Getting Help

--- a/codegen/src/CodeGen.test.scala
+++ b/codegen/src/CodeGen.test.scala
@@ -89,8 +89,8 @@ class CodeGenTest extends munit.FunSuite {
               |
               |  given outputOps: {} with
               |    extension(output: besom.types.Output[Provider])
-              |      def urn: besom.types.Output[besom.types.URN] = output.flatMap(_.urn)
-              |      def id: besom.types.Output[besom.types.ResourceId] = output.flatMap(_.id)
+              |      def urn : besom.types.Output[besom.types.URN] = output.flatMap(_.urn)
+              |      def id : besom.types.Output[besom.types.ResourceId] = output.flatMap(_.id)
               |""".stripMargin,
         "src/index/ProviderArgs.scala" ->
           s"""|package besom.api.example
@@ -115,6 +115,439 @@ class CodeGenTest extends munit.FunSuite {
         "src/index/outputs/HelmReleaseSettings.scala",
         "src/index/outputs/HelmReleaseSettingsArgs.scala",
         "src/index/inputs/HelmReleaseSettingsArgs.scala"
+      )
+    ),
+    Data(
+      name = "Resource with method and a function",
+      json = """|{
+                |  "name": "google-native",
+                |  "resources": {
+                |    "google-native:container/v1:Cluster": {
+                |      "type": "object",
+                |      "properties": {
+                |        "name": {
+                |          "type": "string"
+                |        }
+                |      },
+                |      "required": [
+                |        "name"
+                |      ],
+                |      "methods": {
+                |        "getKubeconfig": "google-native:container/v1:Cluster/getKubeconfig"
+                |      }
+                |    }
+                |  },
+                |  "functions": {
+                |    "google-native:container/v1:Cluster/getKubeconfig": {
+                |      "inputs": {
+                |        "properties": {
+                |          "__self__": {
+                |            "$ref": "#/resources/google-native:container%2Fv1:Cluster"
+                |          }
+                |        },
+                |        "type": "object",
+                |        "required": [
+                |          "__self__"
+                |        ]
+                |      },
+                |      "outputs": {
+                |        "properties": {
+                |          "kubeconfig": {
+                |            "type": "string"
+                |          }
+                |        },
+                |        "type": "object",
+                |        "required": [
+                |          "kubeconfig"
+                |        ]
+                |      }
+                |    },
+                |    "google-native:container/v1:getCluster": {
+                |      "description": "Gets the details of a specific cluster.",
+                |      "inputs": {
+                |        "properties": {
+                |          "clusterId": {
+                |            "type": "string"
+                |          },
+                |          "location": {
+                |            "type": "string"
+                |          }
+                |        },
+                |        "type": "object",
+                |        "required": [
+                |          "clusterId"
+                |        ]
+                |      }
+                |    }
+                |  }
+                |}
+                |""".stripMargin,
+      expected = Map(
+        "src/container/v1/Cluster.scala" ->
+          """|package besom.api.googlenative.container.v1
+             |
+             |final case class Cluster private(
+             |  urn: besom.types.Output[besom.types.URN],
+             |  id: besom.types.Output[besom.types.ResourceId],
+             |  name: besom.types.Output[String]
+             |) extends besom.CustomResource derives besom.ResourceDecoder:
+             |  def getKubeconfig(using ctx: besom.types.Context)(
+             |    args: besom.api.googlenative.container.v1.ClusterGetKubeconfigArgs = besom.api.googlenative.container.v1.ClusterGetKubeconfigArgs(),
+             |    opts: besom.InvokeOptions = besom.InvokeOptions()
+             |  ): besom.types.Output[besom.api.googlenative.container.v1.ClusterGetKubeconfigResult] =
+             |     ctx.call[besom.api.googlenative.container.v1.ClusterGetKubeconfigArgs, besom.api.googlenative.container.v1.ClusterGetKubeconfigResult, besom.api.googlenative.container.v1.Cluster]("google-native:container/v1:Cluster/getKubeconfig", args, this, opts)
+             |
+             |object Cluster:
+             |  def apply(using ctx: besom.types.Context)(
+             |    name: besom.util.NonEmptyString,
+             |    args: ClusterArgs = ClusterArgs(),
+             |    opts: besom.CustomResourceOptions = besom.CustomResourceOptions()
+             |  ): besom.types.Output[Cluster] =
+             |    ctx.registerResource[Cluster, ClusterArgs]("google-native:container/v1:Cluster", name, args, opts)
+             |
+             |  given outputOps: {} with
+             |    extension(output: besom.types.Output[Cluster])
+             |      def urn : besom.types.Output[besom.types.URN] = output.flatMap(_.urn)
+             |      def id : besom.types.Output[besom.types.ResourceId] = output.flatMap(_.id)
+             |      def name : besom.types.Output[String] = output.flatMap(_.name)
+             |""".stripMargin,
+        "src/container/v1/ClusterArgs.scala" ->
+          """|package besom.api.googlenative.container.v1
+             |
+             |final case class ClusterArgs private(
+             |
+             |) derives besom.types.Encoder, besom.types.ArgsEncoder
+             |
+             |
+             |object ClusterArgs:
+             |  def apply(
+             |
+             |  )(using besom.types.Context): ClusterArgs =
+             |    new ClusterArgs(
+             |
+             |    )
+             |""".stripMargin,
+        "src/container/v1/ClusterGetKubeconfigArgs.scala" ->
+          """|package besom.api.googlenative.container.v1
+             |
+             |final case class ClusterGetKubeconfigArgs private(
+             |
+             |) derives besom.types.Encoder, besom.types.ArgsEncoder
+             |
+             |
+             |object ClusterGetKubeconfigArgs:
+             |  def apply(
+             |
+             |  )(using besom.types.Context): ClusterGetKubeconfigArgs =
+             |    new ClusterGetKubeconfigArgs(
+             |
+             |    )
+             |""".stripMargin,
+        "src/container/v1/ClusterGetKubeconfigResult.scala" ->
+          """|package besom.api.googlenative.container.v1
+             |
+             |
+             |final case class ClusterGetKubeconfigResult private(
+             |  kubeconfig: String
+             |) derives besom.types.Decoder
+             |
+             |
+             |object ClusterGetKubeconfigResult :
+             |  given outputOps: {} with
+             |    extension(output: besom.types.Output[ClusterGetKubeconfigResult])
+             |      def kubeconfig : besom.types.Output[String] = output.map(_.kubeconfig)
+             |
+             |  given optionOutputOps: {} with
+             |    extension(output: besom.types.Output[scala.Option[ClusterGetKubeconfigResult]])
+             |      def kubeconfig : besom.types.Output[scala.Option[String]] = output.map(_.map(_.kubeconfig))
+             |""".stripMargin,
+        "src/container/v1/getCluster.scala" ->
+          """|package besom.api.googlenative.container.v1
+             |
+             |def getCluster(using ctx: besom.types.Context)(
+             |  args: besom.api.googlenative.container.v1.GetClusterArgs,
+             |  opts: besom.InvokeOptions = besom.InvokeOptions()
+             |): besom.types.Output[scala.Unit] =
+             |   ctx.invoke[besom.api.googlenative.container.v1.GetClusterArgs, scala.Unit]("google-native:container/v1:getCluster", args, opts)
+             |""".stripMargin,
+        "src/container/v1/GetClusterArgs.scala" ->
+          """|package besom.api.googlenative.container.v1
+             |
+             |final case class GetClusterArgs private(
+             |  clusterId: besom.types.Output[String],
+             |  location: besom.types.Output[scala.Option[String]]
+             |) derives besom.types.Encoder, besom.types.ArgsEncoder
+             |
+             |
+             |object GetClusterArgs:
+             |  def apply(
+             |    clusterId: besom.types.Input[String],
+             |    location: besom.types.Input.Optional[String] = scala.None
+             |  )(using besom.types.Context): GetClusterArgs =
+             |    new GetClusterArgs(
+             |      clusterId = clusterId.asOutput(isSecret = false),
+             |      location = location.asOptionOutput(isSecret = false)
+             |    )
+             |""".stripMargin
+      ),
+      ignored = List(
+        "src/index/Provider.scala",
+        "src/index/ProviderArgs.scala"
+      )
+    ),
+    Data(
+      name = "Enum property with default string union value",
+      json = """|{
+                |  "name": "azure-native",
+                |  "resources": {
+                |    "azure-native:windowsesu:MultipleActivationKey": {
+                |      "properties": {
+                |        "supportType": {
+                |          "type": "string",
+                |          "description": "Type of support",
+                |          "default": "SupplementalServicing"
+                |        }
+                |      },
+                |      "type": "object",
+                |      "inputProperties": {
+                |        "supportType": {
+                |          "oneOf": [
+                |            {
+                |              "type": "string"
+                |            },
+                |            {
+                |              "$ref": "#/types/azure-native:windowsesu:SupportType"
+                |            }
+                |          ],
+                |          "default": "SupplementalServicing"
+                |        }
+                |      }
+                |    }
+                |  },
+                |  "types": {
+                |    "azure-native:windowsesu:SupportType": {
+                |      "type": "string",
+                |      "enum": [
+                |        {
+                |          "value": "SupplementalServicing"
+                |        },
+                |        {
+                |          "value": "PremiumAssurance"
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin,
+      ignored = List(
+        "src/index/Provider.scala",
+        "src/index/ProviderArgs.scala",
+        "src/windowsesu/MultipleActivationKey.scala"
+      ),
+      expected = Map(
+        "src/windowsesu/enums/SupportType.scala" ->
+          """|package besom.api.azurenative.windowsesu.enums
+             |
+             |sealed abstract class SupportType(val name: String, val value: String) extends besom.types.StringEnum
+             |
+             |object SupportType extends besom.types.EnumCompanion[String, SupportType]("SupportType"):
+             |  object SupplementalServicing extends SupportType("SupplementalServicing", "SupplementalServicing")
+             |  object PremiumAssurance extends SupportType("PremiumAssurance", "PremiumAssurance")
+             |
+             |  override val allInstances: Seq[SupportType] = Seq(
+             |    SupplementalServicing,
+             |    PremiumAssurance
+             |  )
+             |""".stripMargin,
+        "src/windowsesu/MultipleActivationKeyArgs.scala" ->
+          """|package besom.api.azurenative.windowsesu
+             |
+             |final case class MultipleActivationKeyArgs private(
+             |  supportType: besom.types.Output[String | besom.api.azurenative.windowsesu.enums.SupportType]
+             |) derives besom.types.Encoder, besom.types.ArgsEncoder
+             |
+             |
+             |object MultipleActivationKeyArgs:
+             |  def apply(
+             |    supportType: besom.types.Input[String | besom.api.azurenative.windowsesu.enums.SupportType] = "SupplementalServicing"
+             |  )(using besom.types.Context): MultipleActivationKeyArgs =
+             |    new MultipleActivationKeyArgs(
+             |      supportType = supportType.asOutput(isSecret = false)
+             |    )
+             |""".stripMargin
+      )
+    ),
+    Data(
+      name = "Enum property with default no string union value",
+      json = """|{
+           |  "name": "azure-native",
+           |  "resources": {
+           |    "azure-native:hybriddata:JobDefinition": {
+           |      "properties": {
+           |        "userConfirmation": {
+           |          "type": "string",
+           |          "description": "Enum to detect if user confirmation is required. If not passed will default to NotRequired.",
+           |          "default": "NotRequired"
+           |        }
+           |      },
+           |      "type": "object",
+           |      "inputProperties": {
+           |        "userConfirmation": {
+           |          "$ref": "#/types/azure-native:hybriddata:UserConfirmation",
+           |          "default": "NotRequired"
+           |        }
+           |      }
+           |    }
+           |  },
+           |  "types": {
+           |    "azure-native:hybriddata:UserConfirmation": {
+           |      "description": "Enum to detect if user confirmation is required. If not passed will default to NotRequired.",
+           |      "type": "string",
+           |      "enum": [
+           |        {
+           |          "value": "NotRequired"
+           |        },
+           |        {
+           |          "value": "Required"
+           |        }
+           |      ]
+           |    }
+           |  }
+           |}
+           |""".stripMargin,
+      ignored = List(
+        "src/index/Provider.scala",
+        "src/index/ProviderArgs.scala",
+        "src/hybriddata/JobDefinition.scala"
+      ),
+      expected = Map(
+        "src/hybriddata/enums/UserConfirmation.scala" ->
+          """|package besom.api.azurenative.hybriddata.enums
+             |
+             |sealed abstract class UserConfirmation(val name: String, val value: String) extends besom.types.StringEnum
+             |
+             |object UserConfirmation extends besom.types.EnumCompanion[String, UserConfirmation]("UserConfirmation"):
+             |  object NotRequired extends UserConfirmation("NotRequired", "NotRequired")
+             |  object Required extends UserConfirmation("Required", "Required")
+             |
+             |  override val allInstances: Seq[UserConfirmation] = Seq(
+             |    NotRequired,
+             |    Required
+             |  )
+             |""".stripMargin,
+        "src/hybriddata/JobDefinitionArgs.scala" ->
+          """|package besom.api.azurenative.hybriddata
+             |
+             |final case class JobDefinitionArgs private(
+             |  userConfirmation: besom.types.Output[besom.api.azurenative.hybriddata.enums.UserConfirmation]
+             |) derives besom.types.Encoder, besom.types.ArgsEncoder
+             |
+             |
+             |object JobDefinitionArgs:
+             |  def apply(
+             |    userConfirmation: besom.types.Input[besom.api.azurenative.hybriddata.enums.UserConfirmation] = besom.api.azurenative.hybriddata.enums.UserConfirmation.NotRequired
+             |  )(using besom.types.Context): JobDefinitionArgs =
+             |    new JobDefinitionArgs(
+             |      userConfirmation = userConfirmation.asOutput(isSecret = false)
+             |    )
+             |""".stripMargin
+      )
+    ),
+    Data(
+      name = "Enum properties with default integer and double values",
+      json = """|{
+                |  "name": "plant",
+                |  "resources": {
+                |    "plant:tree/v1:RubberTree": {
+                |      "inputProperties": {
+                |        "container": {
+                |          "$ref": "#/types/plant::Container"
+                |        }
+                |      },
+                |      "properties": {
+                |        "container": {
+                |          "$ref": "#/types/plant::Container"
+                |        }
+                |      }
+                |    }
+                |  },
+                |  "types": {
+                |    "plant::Container": {
+                |      "type": "object",
+                |      "properties": {
+                |        "size": {
+                |          "$ref": "#/types/plant::ContainerSize",
+                |          "default": 4
+                |        },
+                |        "brightness": {
+                |          "$ref": "#/types/plant::ContainerBrightness",
+                |          "default": 1.0
+                |        }
+                |      }
+                |    },
+                |    "plant::ContainerSize": {
+                |      "type": "integer",
+                |      "description": "plant container sizes",
+                |      "enum": [
+                |        {
+                |          "value": 4,
+                |          "name": "FourInch"
+                |        },
+                |        {
+                |          "value": 6,
+                |          "name": "SixInch"
+                |        },
+                |        {
+                |          "value": 8,
+                |          "name": "EightInch"
+                |        }
+                |      ]
+                |    },
+                |    "plant::ContainerBrightness": {
+                |      "type": "number",
+                |      "enum": [
+                |        {
+                |          "name": "ZeroPointOne",
+                |          "value": 0.1
+                |        },
+                |        {
+                |          "name": "One",
+                |          "value": 1.0
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin,
+      ignored = List(
+        "src/index/Provider.scala",
+        "src/index/ProviderArgs.scala",
+        "src/index/outputs/Container.scala",
+        "src/index/enums/ContainerSize.scala",
+        "src/index/enums/ContainerBrightness.scala",
+        "src/tree/v1/RubberTree.scala",
+        "src/tree/v1/RubberTreeArgs.scala"
+      ),
+      expected = Map(
+        "src/index/inputs/ContainerArgs.scala" ->
+          """|package besom.api.plant.inputs
+             |
+             |final case class ContainerArgs private(
+             |  brightness: besom.types.Output[besom.api.plant.enums.ContainerBrightness],
+             |  size: besom.types.Output[besom.api.plant.enums.ContainerSize]
+             |) derives besom.types.Encoder, besom.types.ArgsEncoder
+             |
+             |
+             |object ContainerArgs:
+             |  def apply(
+             |    brightness: besom.types.Input[besom.api.plant.enums.ContainerBrightness] = besom.api.plant.enums.ContainerBrightness.One,
+             |    size: besom.types.Input[besom.api.plant.enums.ContainerSize] = besom.api.plant.enums.ContainerSize.FourInch
+             |  )(using besom.types.Context): ContainerArgs =
+             |    new ContainerArgs(
+             |      brightness = brightness.asOutput(isSecret = false),
+             |      size = size.asOutput(isSecret = false)
+             |    )
+             |""".stripMargin
       )
     ),
     Data(

--- a/codegen/src/CodeGen.test.scala
+++ b/codegen/src/CodeGen.test.scala
@@ -1,9 +1,9 @@
 package besom.codegen.metaschema
 
+import besom.codegen.*
 import besom.codegen.Config.{CodegenConfig, ProviderConfig}
-import besom.codegen._
 
-import scala.meta._
+import scala.meta.*
 import scala.meta.dialects.Scala33
 
 //noinspection ScalaFileName,TypeAnnotation
@@ -81,10 +81,10 @@ class CodeGenTest extends munit.FunSuite {
               |  ): besom.types.Output[Provider] =
               |    ctx.readOrRegisterResource[Provider, ProviderArgs]("pulumi:providers:example", name, args, opts)
               |
-              |  given resourceDecoder(using besom.types.Context): besom.types.ResourceDecoder[Provider] = 
+              |  given resourceDecoder(using besom.types.Context): besom.types.ResourceDecoder[Provider] =
               |    besom.internal.ResourceDecoder.derived[Provider]
               |
-              |  given decoder(using besom.types.Context): besom.types.Decoder[Provider] = 
+              |  given decoder(using besom.types.Context): besom.types.Decoder[Provider] =
               |    besom.internal.Decoder.customResourceDecoder[Provider]
               |
               |  given outputOps: {} with
@@ -107,7 +107,7 @@ class CodeGenTest extends munit.FunSuite {
               |      helmReleaseSettings = helmReleaseSettings.asOptionOutput(isSecret = false)
               |    )
               |
-              |  given encoder(using besom.types.Context): besom.types.ProviderArgsEncoder[ProviderArgs] = 
+              |  given encoder(using besom.types.Context): besom.types.ProviderArgsEncoder[ProviderArgs] =
               |    besom.internal.ProviderArgsEncoder.derived[ProviderArgs]
               |""".stripMargin
       ),
@@ -190,7 +190,7 @@ class CodeGenTest extends munit.FunSuite {
              |  urn: besom.types.Output[besom.types.URN],
              |  id: besom.types.Output[besom.types.ResourceId],
              |  name: besom.types.Output[String]
-             |) extends besom.CustomResource derives besom.ResourceDecoder:
+             |) extends besom.CustomResource:
              |  def getKubeconfig(using ctx: besom.types.Context)(
              |    args: besom.api.googlenative.container.v1.ClusterGetKubeconfigArgs = besom.api.googlenative.container.v1.ClusterGetKubeconfigArgs(),
              |    opts: besom.InvokeOptions = besom.InvokeOptions()
@@ -203,7 +203,13 @@ class CodeGenTest extends munit.FunSuite {
              |    args: ClusterArgs = ClusterArgs(),
              |    opts: besom.CustomResourceOptions = besom.CustomResourceOptions()
              |  ): besom.types.Output[Cluster] =
-             |    ctx.registerResource[Cluster, ClusterArgs]("google-native:container/v1:Cluster", name, args, opts)
+             |    ctx.readOrRegisterResource[Cluster, ClusterArgs]("google-native:container/v1:Cluster", name, args, opts)
+             |
+             |  given resourceDecoder(using besom.types.Context): besom.types.ResourceDecoder[Cluster] =
+             |    besom.internal.ResourceDecoder.derived[Cluster]
+             |
+             |  given decoder(using besom.types.Context): besom.types.Decoder[Cluster] =
+             |    besom.internal.Decoder.customResourceDecoder[Cluster]
              |
              |  given outputOps: {} with
              |    extension(output: besom.types.Output[Cluster])
@@ -216,8 +222,7 @@ class CodeGenTest extends munit.FunSuite {
              |
              |final case class ClusterArgs private(
              |
-             |) derives besom.types.Encoder, besom.types.ArgsEncoder
-             |
+             |)
              |
              |object ClusterArgs:
              |  def apply(
@@ -226,14 +231,18 @@ class CodeGenTest extends munit.FunSuite {
              |    new ClusterArgs(
              |
              |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[ClusterArgs] =
+             |    besom.internal.Encoder.derived[ClusterArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[ClusterArgs] =
+             |    besom.internal.ArgsEncoder.derived[ClusterArgs]
              |""".stripMargin,
         "src/container/v1/ClusterGetKubeconfigArgs.scala" ->
           """|package besom.api.googlenative.container.v1
              |
              |final case class ClusterGetKubeconfigArgs private(
              |
-             |) derives besom.types.Encoder, besom.types.ArgsEncoder
-             |
+             |)
              |
              |object ClusterGetKubeconfigArgs:
              |  def apply(
@@ -242,6 +251,11 @@ class CodeGenTest extends munit.FunSuite {
              |    new ClusterGetKubeconfigArgs(
              |
              |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[ClusterGetKubeconfigArgs] =
+             |    besom.internal.Encoder.derived[ClusterGetKubeconfigArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[ClusterGetKubeconfigArgs] =
+             |    besom.internal.ArgsEncoder.derived[ClusterGetKubeconfigArgs]
              |""".stripMargin,
         "src/container/v1/ClusterGetKubeconfigResult.scala" ->
           """|package besom.api.googlenative.container.v1
@@ -249,13 +263,15 @@ class CodeGenTest extends munit.FunSuite {
              |
              |final case class ClusterGetKubeconfigResult private(
              |  kubeconfig: String
-             |) derives besom.types.Decoder
-             |
+             |)
              |
              |object ClusterGetKubeconfigResult :
              |  given outputOps: {} with
              |    extension(output: besom.types.Output[ClusterGetKubeconfigResult])
              |      def kubeconfig : besom.types.Output[String] = output.map(_.kubeconfig)
+             |
+             |  given decoder(using besom.types.Context): besom.types.Decoder[ClusterGetKubeconfigResult] =
+             |    besom.internal.Decoder.derived[ClusterGetKubeconfigResult]
              |
              |  given optionOutputOps: {} with
              |    extension(output: besom.types.Output[scala.Option[ClusterGetKubeconfigResult]])
@@ -276,8 +292,7 @@ class CodeGenTest extends munit.FunSuite {
              |final case class GetClusterArgs private(
              |  clusterId: besom.types.Output[String],
              |  location: besom.types.Output[scala.Option[String]]
-             |) derives besom.types.Encoder, besom.types.ArgsEncoder
-             |
+             |)
              |
              |object GetClusterArgs:
              |  def apply(
@@ -288,6 +303,11 @@ class CodeGenTest extends munit.FunSuite {
              |      clusterId = clusterId.asOutput(isSecret = false),
              |      location = location.asOptionOutput(isSecret = false)
              |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[GetClusterArgs] =
+             |    besom.internal.Encoder.derived[GetClusterArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[GetClusterArgs] =
+             |    besom.internal.ArgsEncoder.derived[GetClusterArgs]
              |""".stripMargin
       ),
       ignored = List(
@@ -364,8 +384,7 @@ class CodeGenTest extends munit.FunSuite {
              |
              |final case class MultipleActivationKeyArgs private(
              |  supportType: besom.types.Output[String | besom.api.azurenative.windowsesu.enums.SupportType]
-             |) derives besom.types.Encoder, besom.types.ArgsEncoder
-             |
+             |)
              |
              |object MultipleActivationKeyArgs:
              |  def apply(
@@ -374,47 +393,52 @@ class CodeGenTest extends munit.FunSuite {
              |    new MultipleActivationKeyArgs(
              |      supportType = supportType.asOutput(isSecret = false)
              |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[MultipleActivationKeyArgs] =
+             |    besom.internal.Encoder.derived[MultipleActivationKeyArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[MultipleActivationKeyArgs] =
+             |    besom.internal.ArgsEncoder.derived[MultipleActivationKeyArgs]
              |""".stripMargin
       )
     ),
     Data(
       name = "Enum property with default no string union value",
       json = """|{
-           |  "name": "azure-native",
-           |  "resources": {
-           |    "azure-native:hybriddata:JobDefinition": {
-           |      "properties": {
-           |        "userConfirmation": {
-           |          "type": "string",
-           |          "description": "Enum to detect if user confirmation is required. If not passed will default to NotRequired.",
-           |          "default": "NotRequired"
-           |        }
-           |      },
-           |      "type": "object",
-           |      "inputProperties": {
-           |        "userConfirmation": {
-           |          "$ref": "#/types/azure-native:hybriddata:UserConfirmation",
-           |          "default": "NotRequired"
-           |        }
-           |      }
-           |    }
-           |  },
-           |  "types": {
-           |    "azure-native:hybriddata:UserConfirmation": {
-           |      "description": "Enum to detect if user confirmation is required. If not passed will default to NotRequired.",
-           |      "type": "string",
-           |      "enum": [
-           |        {
-           |          "value": "NotRequired"
-           |        },
-           |        {
-           |          "value": "Required"
-           |        }
-           |      ]
-           |    }
-           |  }
-           |}
-           |""".stripMargin,
+                |  "name": "azure-native",
+                |  "resources": {
+                |    "azure-native:hybriddata:JobDefinition": {
+                |      "properties": {
+                |        "userConfirmation": {
+                |          "type": "string",
+                |          "description": "Enum to detect if user confirmation is required. If not passed will default to NotRequired.",
+                |          "default": "NotRequired"
+                |        }
+                |      },
+                |      "type": "object",
+                |      "inputProperties": {
+                |        "userConfirmation": {
+                |          "$ref": "#/types/azure-native:hybriddata:UserConfirmation",
+                |          "default": "NotRequired"
+                |        }
+                |      }
+                |    }
+                |  },
+                |  "types": {
+                |    "azure-native:hybriddata:UserConfirmation": {
+                |      "description": "Enum to detect if user confirmation is required. If not passed will default to NotRequired.",
+                |      "type": "string",
+                |      "enum": [
+                |        {
+                |          "value": "NotRequired"
+                |        },
+                |        {
+                |          "value": "Required"
+                |        }
+                |      ]
+                |    }
+                |  }
+                |}
+                |""".stripMargin,
       ignored = List(
         "src/index/Provider.scala",
         "src/index/ProviderArgs.scala",
@@ -440,8 +464,7 @@ class CodeGenTest extends munit.FunSuite {
              |
              |final case class JobDefinitionArgs private(
              |  userConfirmation: besom.types.Output[besom.api.azurenative.hybriddata.enums.UserConfirmation]
-             |) derives besom.types.Encoder, besom.types.ArgsEncoder
-             |
+             |)
              |
              |object JobDefinitionArgs:
              |  def apply(
@@ -450,6 +473,11 @@ class CodeGenTest extends munit.FunSuite {
              |    new JobDefinitionArgs(
              |      userConfirmation = userConfirmation.asOutput(isSecret = false)
              |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[JobDefinitionArgs] =
+             |    besom.internal.Encoder.derived[JobDefinitionArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[JobDefinitionArgs] =
+             |    besom.internal.ArgsEncoder.derived[JobDefinitionArgs]
              |""".stripMargin
       )
     ),
@@ -535,8 +563,7 @@ class CodeGenTest extends munit.FunSuite {
              |final case class ContainerArgs private(
              |  brightness: besom.types.Output[besom.api.plant.enums.ContainerBrightness],
              |  size: besom.types.Output[besom.api.plant.enums.ContainerSize]
-             |) derives besom.types.Encoder, besom.types.ArgsEncoder
-             |
+             |)
              |
              |object ContainerArgs:
              |  def apply(
@@ -547,6 +574,11 @@ class CodeGenTest extends munit.FunSuite {
              |      brightness = brightness.asOutput(isSecret = false),
              |      size = size.asOutput(isSecret = false)
              |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[ContainerArgs] =
+             |    besom.internal.Encoder.derived[ContainerArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[ContainerArgs] =
+             |    besom.internal.ArgsEncoder.derived[ContainerArgs]
              |""".stripMargin
       )
     ),

--- a/codegen/src/Logger.scala
+++ b/codegen/src/Logger.scala
@@ -34,7 +34,9 @@ class Logger(val printLevel: Logger.Level = Logger.Level.Info) {
   def writeToFile(file: os.Path): Unit =
     os.write(file, buffer, createFolders = true)
 
-  def hasProblems: Boolean = errorCount + warnCount > 0
+  def hasWarnings: Boolean = warnCount > 0
+
+  def hasErrors: Boolean = errorCount > 0
 }
 
 object Logger {

--- a/codegen/src/Main.scala
+++ b/codegen/src/Main.scala
@@ -92,7 +92,7 @@ object generator {
       config.outputDir.getOrElse(os.rel / packageName / packageVersion.asString).resolveFrom(config.codegenDir)
 
     val total = generatePackageSources(pulumiPackage, packageInfo, outputDir)
-    logger.info(s"Finished generating package '$packageName:$packageVersion' codebase (${total} files)})")
+    logger.info(s"Finished generating package '$packageName:$packageVersion' codebase (${total} files)")
 
     val dependencies = schemaProvider.dependencies(packageName, packageVersion).map { case (name, version) =>
       PackageMetadata(name, Some(version))

--- a/codegen/src/PropertyInfo.test.scala
+++ b/codegen/src/PropertyInfo.test.scala
@@ -16,6 +16,7 @@ class PropertyInfoTest extends munit.FunSuite {
     expectedName: String,
     expectedType: String,
     expectedArgsType: Option[String] = None,
+    expectedInputArgsType: Option[String] = None,
     metadata: PackageMetadata = TestPackageMetadata,
     tags: Set[munit.Tag] = Set()
   )
@@ -90,7 +91,8 @@ class PropertyInfoTest extends munit.FunSuite {
                 |""".stripMargin,
       expectedName = "pod",
       expectedType = "besom.api.kubernetes.core.v1.outputs.Pod",
-      expectedArgsType = Some("besom.api.kubernetes.core.v1.inputs.PodArgs")
+      expectedArgsType = Some("besom.api.kubernetes.core.v1.inputs.PodArgs"),
+      expectedInputArgsType = Some("besom.api.kubernetes.core.v1.inputs.PodArgs")
     ),
     Data(
       name = "property named enum",
@@ -105,6 +107,7 @@ class PropertyInfoTest extends munit.FunSuite {
                 |""".stripMargin,
       expectedName = "`enum`",
       expectedType = "scala.collection.immutable.List[besom.types.PulumiJson]",
+      expectedInputArgsType = Some("scala.collection.immutable.List[besom.types.Input[besom.types.PulumiJson]]")
     )
   ).foreach(data =>
     test(data.name.withTags(data.tags)) {
@@ -124,10 +127,8 @@ class PropertyInfoTest extends munit.FunSuite {
 
       assertEquals(property.name.syntax, data.expectedName)
       assertEquals(property.baseType.syntax, data.expectedType)
-      assertEquals(
-        property.argType.syntax,
-        data.expectedArgsType.getOrElse(data.expectedType)
-      )
+      assertEquals(property.argType.syntax, data.expectedArgsType.getOrElse(data.expectedType))
+      assertEquals(property.inputArgType.syntax, data.expectedInputArgsType.getOrElse(data.expectedType))
     }
   )
 }

--- a/codegen/src/PulumiDefinitionCoordinates.test.scala
+++ b/codegen/src/PulumiDefinitionCoordinates.test.scala
@@ -123,8 +123,8 @@ class PulumiDefinitionCoordinatesTest extends munit.FunSuite {
     )(
       ResourceClassExpectations(
         fullPackageName = "besom.api.kubernetes.meta.v1",
-        fullyQualifiedTypeRef = "besom.api.kubernetes.meta.v1.APIVersions",
-        filePath = "src/meta/v1/APIVersions.scala"
+        fullyQualifiedTypeRef = "besom.api.kubernetes.meta.v1.ApiVersions",
+        filePath = "src/meta/v1/ApiVersions.scala"
       )
     ),
     Data(
@@ -192,12 +192,11 @@ class PulumiDefinitionCoordinatesTest extends munit.FunSuite {
       )
     )(
       FunctionClassExpectations(
-        fullPackageName =
-          "besom.api.eks.Cluster", // this one is tricky, because it is technically not a package, but a class
+        fullPackageName = "besom.api.eks",
         fullyQualifiedTypeRef = "besom.api.eks.Cluster.getKubeconfig",
         // this will not be used actually because it is a class method and not a standalone function
         // but we include this anyway to document the current behaviour
-        filePath = "src/index/Cluster/getKubeconfig.scala",
+        filePath = "src/index/Cluster.scala",
         args = FunctionClassExpectations.FunctionClassExpectationsArgs(
           fullPackageName = "besom.api.eks",
           fullyQualifiedTypeRef = "besom.api.eks.ClusterGetKubeconfigArgs",
@@ -247,6 +246,24 @@ class PulumiDefinitionCoordinatesTest extends munit.FunSuite {
           assertEquals(rc.typeRef.syntax, result.fullyQualifiedTypeRef)
           assertEquals(rc.filePath.osSubPath.toString(), result.filePath)
       }
+    }
+  }
+
+  test("normalize strings correctly") {
+    val testCases = Map(
+      "A" -> "A",
+      "ID" -> "Id",
+      "JSONPatch" -> "JsonPatch",
+      "URLParser" -> "UrlParser",
+      "camelCase" -> "CamelCase",
+      "PascalCase" -> "PascalCase",
+      "lowercase" -> "Lowercase",
+      "UPPERCASE" -> "Uppercase",
+      "ListenerXForwardedForConfig" -> "ListenerxForwardedForConfig",
+    )
+
+    for ((input, expected) <- testCases) {
+      assertEquals(PulumiDefinitionCoordinates.normalize(input), expected)
     }
   }
 }

--- a/codegen/src/PulumiPackageInfo.scala
+++ b/codegen/src/PulumiPackageInfo.scala
@@ -2,6 +2,9 @@ package besom.codegen
 
 import besom.codegen.PackageMetadata.SchemaName
 import besom.codegen.PackageVersion
+import besom.codegen.metaschema.ConstValue
+
+type EnumInstanceName = String
 
 case class PulumiPackageInfo(
   name: SchemaName,
@@ -11,7 +14,8 @@ case class PulumiPackageInfo(
   providerTypeToken: String,
   resourceTypeTokens: Set[String],
   moduleToPackageParts: String => Seq[String],
-  providerToPackageParts: String => Seq[String]
+  providerToPackageParts: String => Seq[String],
+  enumValueToInstances: Map[PulumiToken, Map[ConstValue, EnumInstanceName]]
 ) {
   def asPackageMetadata: PackageMetadata = PackageMetadata(name, Some(version))
 }

--- a/codegen/src/ScalaDefinitionCoordinates.test.scala
+++ b/codegen/src/ScalaDefinitionCoordinates.test.scala
@@ -43,7 +43,7 @@ class ScalaDefinitionCoordinatesTest extends munit.FunSuite {
     ),
     Data(
       providerPackageParts = "aws-native" :: Nil,
-      modulePackageParts = "index" :: "region" :: Nil,
+      modulePackageParts = "index" :: "Region" :: Nil, // unexpected upper case
       definitionName = "Region"
     )(
       Expectations(
@@ -59,7 +59,7 @@ class ScalaDefinitionCoordinatesTest extends munit.FunSuite {
       val coords: ScalaDefinitionCoordinates = ScalaDefinitionCoordinates(
         providerPackageParts = data.providerPackageParts,
         modulePackageParts = data.modulePackageParts,
-        definitionName = data.definitionName
+        definitionName = Some(data.definitionName)
       )
 
       assertEquals(coords.packageRef.syntax, data.expected.fullPackageName)

--- a/codegen/src/TypeMapper.test.scala
+++ b/codegen/src/TypeMapper.test.scala
@@ -113,7 +113,6 @@ class TypeMapperTest extends munit.FunSuite {
     Data(NumberType)(Expectations("Double")),
     Data(StringType)(Expectations("String")),
     Data(UnionType(List(StringType, NumberType), None))(Expectations("String | Double"))
-    // TODO: input tests
   )
 
   tests.foreach { data =>

--- a/codegen/src/Utils.scala
+++ b/codegen/src/Utils.scala
@@ -148,7 +148,7 @@ object Utils {
     def parsedMethods(
       resourceDefinition: ResourceDefinition
     )(implicit logger: Logger): Map[FunctionName, (PulumiDefinitionCoordinates, FunctionDefinition)] = {
-      val (notMethods, methods) = resourceDefinition.methods.toSeq
+      val (methods, notMethods) = resourceDefinition.methods.toSeq
         .sortBy { case (name, _) => name }
         .map { case (name, token) =>
           (

--- a/integration-tests/CodegenTests.test.scala
+++ b/integration-tests/CodegenTests.test.scala
@@ -31,19 +31,15 @@ class CodegenTests extends munit.FunSuite {
 
   // FIXME: broken - codegen error
   val ignoreList = List(
-    "simple-enum-schema", // simple enum is not supported
     "simple-yaml-schema", // YAML is not supported
     "external-enum", // depends on google-native, TODO: check if this is still broken
     "enum-reference", // depends on google-native, TODO: check if this is still broken
-    "different-enum", // simple enum is not supported
     "hyphen-url", // depends on azure-native,
     "naming-collisions", // codec not found
-    "mini-azurenative", // simple enum is not supported
+    "mini-azurenative", // decoder for union of 3 missing
     "cyclic-types", // YAML schema is not supported
-    "plain-and-default", // simple enum is not supported
     "different-package-name-conflict", // duplicate issue
     "output-funcs", // deserialize issue
-    "dashed-import-schema", // simple enum is not supported
     "output-funcs-edgeorder", // missing union decoder issue
     "other-owned" // codec not found
   )

--- a/integration-tests/integration.scala
+++ b/integration-tests/integration.scala
@@ -255,6 +255,8 @@ object scalaCli {
     "--power",
     "publish",
     "local",
+    "--sources=false",
+    "--doc=false",
     "--suppress-experimental-feature-warning",
     "--suppress-directives-in-multiple-files-warning",
     "--jvm=17",


### PR DESCRIPTION
- fix method generation
- don't generate `__self__` properties on methods
- normalize type names to consistent CameCase, .e.g. IPAddress -> IpAddress
- add a space between method names ending witn underscore and the colon
- fix enum param default values - lookup instance by value in gen-time