### PR TITLE
Update codegen and package generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,15 +129,15 @@ just install-language-plugin
 
 You have to generate an SDK for a provider of your choice, to do that run:
 ```bash
-just generate-provider-sdk ${provider_name} ${provider_version}
-just publish-local-provider-sdk ${provider_name} ${provider_version}
+just generate-provider ${provider_name} ${provider_version}
+just publish-local-provider ${provider_name} ${provider_version}
 ```
 
 e.g.:
 
 ```bash
-just generate-provider-sdk kubernetes 4.2.0
-just publish-local-provider-sdk kubernetes 4.2.0
+just generate-provider kubernetes 4.2.0
+just publish-local-provider kubernetes 4.2.0
 ```
 
 ### Working with published dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,6 +368,12 @@ To increase Scala compiler verbosity:
 scala-cli compile --javac-opt=-verbose .
 ```
 
+To inspect a running JVM byt its PID use `jcmd`, e.g.:
+```bash
+jcmd 25776 VM.flags
+jcmd 25776 GC.heap_info
+```
+
 ## Getting Help
 
 We are sure there are rough edges, and we appreciate you helping out.

--- a/Justfile
+++ b/Justfile
@@ -432,15 +432,15 @@ liftoff:
 	#!/usr/bin/env sh
 	export PULUMI_CONFIG_PASSPHRASE=""
 	cd experimental
-	pulumi --non-interactive --logtostderrup --stack liftoff -y
+	pulumi --non-interactive --logtostderr up--stack liftoff -y
 
 # Reverts the deployment of experimental sample kubernetes Pulumi app from ./experimental directory
 destroy-liftoff:
 	#!/usr/bin/env sh
 	cd experimental
-	if (pulumi --non-interactive --logtostderrstack ls | grep liftoff > /dev/null); then
+	if (pulumi --non-interactive --logtostderr stack ls | grep liftoff > /dev/null); then
 		export PULUMI_CONFIG_PASSPHRASE=""
-		pulumi  --non-interactive --logtostderrdestroy --stack liftoff -y
+		pulumi  --non-interactive --logtostderr destroy --stack liftoff -y
 	fi
 
 # Cleans the deployment of experimental sample kubernetes Pulumi app from ./experimental directory to the ground

--- a/Justfile
+++ b/Justfile
@@ -48,6 +48,9 @@ compile-all: compile-json compile-sdk compile-codegen compile-compiler-plugin bu
 # Tests everything
 test-all: test-json test-sdk test-codegen test-integration test-templates test-examples test-markdown
 
+# Publishes everything locally
+publish-local-all: publish-local-json publish-local-sdk publish-local-codegen publish-local-compiler-plugin install-language-plugin
+
 # Runs all necessary checks before committing
 before-commit: compile-all test-all
 
@@ -79,7 +82,7 @@ compile-compiler-plugin:
 	scala-cli --power compile compiler-plugin --suppress-experimental-feature-warning
 
 # Runs tests for core besom SDK
-test-core:
+test-core: compile-core
 	@if [ {{ coverage }} = "true" ]; then mkdir -p {{coverage-output-dir-core}}; fi
 	scala-cli --power test core {{ scala-cli-test-options-core }} --suppress-experimental-feature-warning
 
@@ -170,15 +173,19 @@ clean-coverage: clean-sdk
 compile-json:
     scala-cli --power compile besom-json --suppress-experimental-feature-warning
 
+# Runs tests for json module
 test-json:
     scala-cli --power test besom-json --suppress-experimental-feature-warning
 
+# Cleans json module
 clean-json:
     scala-cli --power clean besom-json
 
+# Publishes locally json module
 publish-local-json:
     scala-cli --power publish local besom-json --project-version {{besom-version}} --suppress-experimental-feature-warning
 
+# Publishes json module
 publish-maven-json:
     scala-cli --power publish besom-json --project-version {{besom-version}} {{publish-maven-auth-options}}
 
@@ -252,6 +259,10 @@ compile-codegen:
 test-codegen:
 	scala-cli --power test codegen --suppress-experimental-feature-warning
 
+# Publishes locally besom codegen
+publish-local-codegen: test-codegen
+	scala-cli --power publish local codegen --project-version {{besom-version}} --suppress-experimental-feature-warning
+
 # Dowloads Pulumi Packages metadata for all providers in the registry
 get-metadata-all:
 	export GITHUB_TOKEN=$(gh auth token); \
@@ -275,24 +286,20 @@ get-schema schema-name schema-version:
 	mkdir -p $schema_dir
 	pulumi --non-interactive --logtostderr package get-schema $schema_source > $schema_dir/schema.json
 
-# Publishes locally besom codegen
-publish-local-codegen: test-codegen
-	scala-cli --power publish local codegen --project-version {{besom-version}} --suppress-experimental-feature-warning
-
-# Generate scala API code for the given provider, e.g. `just generate-provider-sdk kubernetes 4.0.0`
-generate-provider-sdk schema-name schema-version:
+# Generate scala API code for the given provider, e.g. `just generate-provider kubernetes 4.0.0`
+generate-provider schema-name schema-version:
 	scala-cli --power run codegen --suppress-experimental-feature-warning -- named {{schema-name}} {{schema-version}}
 
-# Compiles the previously generated scala API code for the given provider, e.g. `just compile-provider-sdk kubernetes 4.0.0`
-compile-provider-sdk schema-name schema-version:
+# Compiles the previously generated scala API code for the given provider, e.g. `just compile-provider kubernetes 4.0.0`
+compile-provider schema-name schema-version:
 	scala-cli --power compile {{scala-cli-publish-local-opts}} {{codegen-output-dir}}/{{schema-name}}/{{schema-version}} --suppress-experimental-feature-warning --interactive=false
 
-# Compiles and publishes locally the previously generated scala API code for the given provider, e.g. `just publish-local-provider-sdk kubernetes 4.0.0`
-publish-local-provider-sdk schema-name schema-version:
+# Compiles and publishes locally the previously generated scala API code for the given provider, e.g. `just publish-local-provider kubernetes 4.0.0`
+publish-local-provider schema-name schema-version:
 	scala-cli --power publish local --sources=false --doc=false {{scala-cli-publish-local-opts}} {{codegen-output-dir}}/{{schema-name}}/{{schema-version}} --suppress-experimental-feature-warning
 
-# Compiles and publishes the previously generated scala API code for the given provider, e.g. `just publish-maven-provider-sdk kubernetes 4.0.0`
-publish-maven-provider-sdk schema-name schema-version:
+# Compiles and publishes the previously generated scala API code for the given provider, e.g. `just publish-maven-provider kubernetes 4.0.0`
+publish-maven-provider schema-name schema-version:
 	scala-cli --power publish {{codegen-output-dir}}/{{schema-name}}/{{schema-version}} {{publish-maven-auth-options}}
 
 ####################
@@ -410,6 +417,7 @@ compile-scripts: publish-local-codegen
 clean-scripts:
     scala-cli --power clean scripts
 
+# Update Besom version
 bump-version new-version:
     scala-cli run scripts/Version.scala -- bump {{new-version}}
 
@@ -420,7 +428,7 @@ bump-version new-version:
 # Cleans everything, including the local ivy, git untracked files, and kills all java processes
 power-wash: clean-all
 	rm -rf ~/.ivy2/local/org.virtuslab/
-	git clean -i -d -x
+	git clean -i -d -x -e ".idea"
 	killall -9 java
 
 ####################
@@ -456,10 +464,10 @@ clean-liftoff: destroy-liftoff
 # Cleans the deployment of ./experimental app completely, rebuilds core and kubernetes provider SDKs, deploys the app again
 clean-slate-liftoff: clean-sdk
 	#!/usr/bin/env sh
-	just generate-provider-sdk kubernetes 4.2.0 
+	just generate-provider kubernetes 4.2.0
 	just publish-local-core
 	just publish-local-compiler-plugin
-	just publish-local-provider-sdk kubernetes 4.2.0
+	just publish-local-provider kubernetes 4.2.0
 	just clean-liftoff
 	just liftoff
 

--- a/Justfile
+++ b/Justfile
@@ -432,7 +432,7 @@ liftoff:
 	#!/usr/bin/env sh
 	export PULUMI_CONFIG_PASSPHRASE=""
 	cd experimental
-	pulumi --non-interactive --logtostderr up--stack liftoff -y
+	pulumi --non-interactive --logtostderr up --stack liftoff -y
 
 # Reverts the deployment of experimental sample kubernetes Pulumi app from ./experimental directory
 destroy-liftoff:

--- a/codegen/project.scala
+++ b/codegen/project.scala
@@ -1,5 +1,5 @@
 //> using scala 3.3.1
-//> using options -release:11 -deprecation -Werror -Wunused:all -Wvalue-discard -Wnonunit-statement
+//> using options -release:11 -deprecation -Werror -Wunused:all -Wvalue-discard -Wnonunit-statement -language:noAutoTupling
 
 //> using dep org.scalameta:scalameta_2.13:4.8.14
 //> using dep com.lihaoyi::upickle:3.1.3

--- a/codegen/src/CodeGen.scala
+++ b/codegen/src/CodeGen.scala
@@ -406,7 +406,7 @@ class CodeGen(implicit
         if (!methodCoordinates.definitionName.contains(name)) {
           logger.warn(
             s"""|Resource definition method name '${name}' (used) does not match the name
-                |in method definition '${methodCoordinates.definitionName}' (ignored)
+                |in method definition '${methodCoordinates.definitionName.getOrElse("")}' (ignored)
                 |for function '${functionToken.asString}' - this is a schema error""".stripMargin
           )
         }
@@ -637,7 +637,7 @@ class CodeGen(implicit
       }
       val description = configDefinition.description.getOrElse("")
       val deprecationCode = configDefinition.deprecationMessage match {
-        case Some(message) => s"""\n  @deprecated("$message")"""
+        case Some(message) => s"""\n@deprecated("$message")"""
         case None          => ""
       }
       val deprecationDocs = configDefinition.deprecationMessage match {
@@ -892,7 +892,7 @@ class CodeGen(implicit
 
     val derivedTypeclasses = {
       lazy val providerArgsEncoderInstance =
-        m"""|  given encoder(using besom.types.Context): besom.types.ProviderArgsEncoder[$argsClassName] =
+        m"""|  given providerArgsEncoder(using besom.types.Context): besom.types.ProviderArgsEncoder[$argsClassName] =
             |    besom.internal.ProviderArgsEncoder.derived[$argsClassName]
             |""".stripMargin
 
@@ -901,7 +901,10 @@ class CodeGen(implicit
             |    besom.internal.ArgsEncoder.derived[$argsClassName]
             |""".stripMargin
 
-      if (isProvider) providerArgsEncoderInstance
+      if (isProvider)
+        m"""|  given encoder(using besom.types.Context): besom.types.Encoder[$argsClassName] =
+            |    besom.internal.Encoder.derived[$argsClassName]
+            |$providerArgsEncoderInstance""".stripMargin
       else if (isResource)
         m"""|  given encoder(using besom.types.Context): besom.types.Encoder[$argsClassName] =
             |    besom.internal.Encoder.derived[$argsClassName]

--- a/codegen/src/CodeGen.scala
+++ b/codegen/src/CodeGen.scala
@@ -127,7 +127,10 @@ class CodeGen(implicit
     pulumiPackage.parsedTypes.flatMap { case (coordinates, typeDefinition) =>
       typeDefinition match {
         case enumDef: EnumTypeDefinition =>
-          sourceFilesForEnum(typeCoordinates = coordinates, enumDefinition = enumDef)
+          sourceFilesForEnum(
+            typeCoordinates = coordinates,
+            enumDefinition = enumDef
+          )
         case objectDef: ObjectTypeDefinition =>
           sourceFilesForObjectType(
             typeCoordinates = coordinates,
@@ -144,7 +147,7 @@ class CodeGen(implicit
   ): Seq[SourceFile] = {
     val classCoordinates = typeCoordinates.asEnumClass
 
-    val enumClassName = classCoordinates.definitionTermName.getOrElse(
+    val enumClassName = classCoordinates.definitionTypeName.getOrElse(
       throw GeneralCodegenException(
         s"Class name for ${classCoordinates.typeRef} could not be found"
       )
@@ -191,6 +194,7 @@ class CodeGen(implicit
           |  override val allInstances: Seq[${enumClassName}] = Seq(
           |${instances.map(instance => s"    ${instance._2.syntax}").mkString(",\n")}
           |  )
+          |  given besom.types.EnumCompanion[${valueType}, ${enumClassName}] = this
           |""".stripMargin.parse[Source].get
 
     Seq(

--- a/codegen/src/CodeGen.scala
+++ b/codegen/src/CodeGen.scala
@@ -794,7 +794,7 @@ class CodeGen(implicit
            |""".stripMargin
 
       lazy val argsEncoderInstance =
-         m"""  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[$argsClassName] =
+        m"""  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[$argsClassName] =
             |    besom.internal.ArgsEncoder.derived[$argsClassName]
             |""".stripMargin
 

--- a/codegen/src/CodeGen.test.scala
+++ b/codegen/src/CodeGen.test.scala
@@ -107,7 +107,9 @@ class CodeGenTest extends munit.FunSuite {
               |      helmReleaseSettings = helmReleaseSettings.asOptionOutput(isSecret = false)
               |    )
               |
-              |  given encoder(using besom.types.Context): besom.types.ProviderArgsEncoder[ProviderArgs] =
+              |  given encoder(using besom.types.Context): besom.types.Encoder[ProviderArgs] =
+              |    besom.internal.Encoder.derived[ProviderArgs]
+              |  given providerArgsEncoder(using besom.types.Context): besom.types.ProviderArgsEncoder[ProviderArgs] =
               |    besom.internal.ProviderArgsEncoder.derived[ProviderArgs]
               |""".stripMargin
       ),

--- a/codegen/src/CodeGen.test.scala
+++ b/codegen/src/CodeGen.test.scala
@@ -379,6 +379,7 @@ class CodeGenTest extends munit.FunSuite {
              |    SupplementalServicing,
              |    PremiumAssurance
              |  )
+             |  given besom.types.EnumCompanion[String, SupportType] = this
              |""".stripMargin,
         "src/windowsesu/MultipleActivationKeyArgs.scala" ->
           """|package besom.api.azurenative.windowsesu
@@ -459,6 +460,7 @@ class CodeGenTest extends munit.FunSuite {
              |    NotRequired,
              |    Required
              |  )
+             |  given besom.types.EnumCompanion[String, UserConfirmation] = this
              |""".stripMargin,
         "src/hybriddata/JobDefinitionArgs.scala" ->
           """|package besom.api.azurenative.hybriddata

--- a/codegen/src/CodeGen.test.scala
+++ b/codegen/src/CodeGen.test.scala
@@ -264,8 +264,9 @@ class CodeGenTest extends munit.FunSuite {
              |final case class ClusterGetKubeconfigResult private(
              |  kubeconfig: String
              |)
-             |
              |object ClusterGetKubeconfigResult :
+             |
+             |
              |  given outputOps: {} with
              |    extension(output: besom.types.Output[ClusterGetKubeconfigResult])
              |      def kubeconfig : besom.types.Output[String] = output.map(_.kubeconfig)
@@ -635,6 +636,8 @@ class CodeGenTest extends munit.FunSuite {
              |  spec: scala.Option[besom.api.kubernetes.crdk8samazonawscom.v1alpha1.outputs.EniConfigSpec]
              |)
              |object EniConfig :
+             |
+             |
              |  given outputOps: {} with
              |    extension(output: besom.types.Output[EniConfig])
              |      def apiVersion : besom.types.Output[String] = output.map(_.apiVersion)
@@ -688,6 +691,8 @@ class CodeGenTest extends munit.FunSuite {
              |  subnet: scala.Option[String]
              |)
              |object EniConfigSpec :
+             |
+             |
              |  given outputOps: {} with
              |    extension(output: besom.types.Output[EniConfigSpec])
              |      def securityGroups : besom.types.Output[scala.Option[scala.collection.immutable.List[String]]] = output.map(_.securityGroups)
@@ -800,9 +805,9 @@ class CodeGenTest extends munit.FunSuite {
 
       val codegen = new CodeGen
       if (data.expectedError.isDefined)
-        interceptMessage[Exception](data.expectedError.get)(codegen.scalaFiles(pulumiPackage))
+        interceptMessage[Exception](data.expectedError.get)(codegen.scalaFiles(pulumiPackage, packageInfo))
       else
-        codegen.scalaFiles(pulumiPackage).foreach {
+        codegen.scalaFiles(pulumiPackage, packageInfo).foreach {
           case SourceFile(FilePath(f: String), code: String) if data.expected.contains(f) =>
             assertNoDiff(code, data.expected(f))
             code.parse[Source].get

--- a/codegen/src/CodeGen.test.scala
+++ b/codegen/src/CodeGen.test.scala
@@ -583,6 +583,153 @@ class CodeGenTest extends munit.FunSuite {
       )
     ),
     Data(
+      name = "Type with dots in package segment",
+      json = """|{
+                |  "name": "embedded-crd",
+                |  "types": {
+                |    "kubernetes:crd.k8s.amazonaws.com/v1alpha1:ENIConfig": {
+                |      "properties": {
+                |        "apiVersion": {
+                |          "type": "string",
+                |          "const": "crd.k8s.amazonaws.com/v1alpha1"
+                |        },
+                |        "kind": {
+                |          "type": "string",
+                |          "const": "ENIConfig"
+                |        },
+                |        "spec": {
+                |          "type": "object",
+                |          "$ref": "#/types/kubernetes:crd.k8s.amazonaws.com/v1alpha1:ENIConfigSpec"
+                |        }
+                |      },
+                |      "type": "object"
+                |    },
+                |    "kubernetes:crd.k8s.amazonaws.com/v1alpha1:ENIConfigSpec": {
+                |      "properties": {
+                |        "securityGroups": {
+                |          "type": "array",
+                |          "items": {
+                |            "type": "string"
+                |          }
+                |        },
+                |        "subnet": {
+                |          "type": "string"
+                |        }
+                |      },
+                |      "type": "object"
+                |    }
+                |  }
+                |}""".stripMargin,
+      ignored = List(
+        "src/index/Provider.scala",
+        "src/index/ProviderArgs.scala"
+      ),
+      expected = Map(
+        "src/crdk8samazonawscom/v1alpha1/outputs/EniConfig.scala" ->
+          """|package besom.api.kubernetes.crdk8samazonawscom.v1alpha1.outputs
+             |
+             |
+             |final case class EniConfig private(
+             |  apiVersion: String,
+             |  kind: String,
+             |  spec: scala.Option[besom.api.kubernetes.crdk8samazonawscom.v1alpha1.outputs.EniConfigSpec]
+             |)
+             |object EniConfig :
+             |  given outputOps: {} with
+             |    extension(output: besom.types.Output[EniConfig])
+             |      def apiVersion : besom.types.Output[String] = output.map(_.apiVersion)
+             |      def kind : besom.types.Output[String] = output.map(_.kind)
+             |      def spec : besom.types.Output[scala.Option[besom.api.kubernetes.crdk8samazonawscom.v1alpha1.outputs.EniConfigSpec]] = output.map(_.spec)
+             |
+             |  given decoder(using besom.types.Context): besom.types.Decoder[EniConfig] =
+             |    besom.internal.Decoder.derived[EniConfig]
+             |
+             |  given optionOutputOps: {} with
+             |    extension(output: besom.types.Output[scala.Option[EniConfig]])
+             |      def apiVersion : besom.types.Output[scala.Option[String]] = output.map(_.map(_.apiVersion))
+             |      def kind : besom.types.Output[scala.Option[String]] = output.map(_.map(_.kind))
+             |      def spec : besom.types.Output[scala.Option[besom.api.kubernetes.crdk8samazonawscom.v1alpha1.outputs.EniConfigSpec]] = output.map(_.flatMap(_.spec))
+             |
+             |
+             |
+             |""".stripMargin,
+        "src/crdk8samazonawscom/v1alpha1/inputs/EniConfigArgs.scala" ->
+          """|package besom.api.kubernetes.crdk8samazonawscom.v1alpha1.inputs
+             |
+             |final case class EniConfigArgs private(
+             |  apiVersion: besom.types.Output[String],
+             |  kind: besom.types.Output[String],
+             |  spec: besom.types.Output[scala.Option[besom.api.kubernetes.crdk8samazonawscom.v1alpha1.inputs.EniConfigSpecArgs]]
+             |)
+             |
+             |object EniConfigArgs:
+             |  def apply(
+             |    spec: besom.types.Input.Optional[besom.api.kubernetes.crdk8samazonawscom.v1alpha1.inputs.EniConfigSpecArgs] = scala.None
+             |  )(using besom.types.Context): EniConfigArgs =
+             |    new EniConfigArgs(
+             |      apiVersion = besom.types.Output("crd.k8s.amazonaws.com/v1alpha1"),
+             |      kind = besom.types.Output("ENIConfig"),
+             |      spec = spec.asOptionOutput(isSecret = false)
+             |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[EniConfigArgs] =
+             |    besom.internal.Encoder.derived[EniConfigArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[EniConfigArgs] =
+             |    besom.internal.ArgsEncoder.derived[EniConfigArgs]
+             |
+             |
+             |""".stripMargin,
+        "src/crdk8samazonawscom/v1alpha1/outputs/EniConfigSpec.scala" ->
+          """|package besom.api.kubernetes.crdk8samazonawscom.v1alpha1.outputs
+             |
+             |
+             |final case class EniConfigSpec private(
+             |  securityGroups: scala.Option[scala.collection.immutable.List[String]],
+             |  subnet: scala.Option[String]
+             |)
+             |object EniConfigSpec :
+             |  given outputOps: {} with
+             |    extension(output: besom.types.Output[EniConfigSpec])
+             |      def securityGroups : besom.types.Output[scala.Option[scala.collection.immutable.List[String]]] = output.map(_.securityGroups)
+             |      def subnet : besom.types.Output[scala.Option[String]] = output.map(_.subnet)
+             |
+             |  given decoder(using besom.types.Context): besom.types.Decoder[EniConfigSpec] =
+             |    besom.internal.Decoder.derived[EniConfigSpec]
+             |
+             |  given optionOutputOps: {} with
+             |    extension(output: besom.types.Output[scala.Option[EniConfigSpec]])
+             |      def securityGroups : besom.types.Output[scala.Option[scala.collection.immutable.List[String]]] = output.map(_.flatMap(_.securityGroups))
+             |      def subnet : besom.types.Output[scala.Option[String]] = output.map(_.flatMap(_.subnet))
+             |
+             |
+             |
+             |""".stripMargin,
+        "src/crdk8samazonawscom/v1alpha1/inputs/EniConfigSpecArgs.scala" ->
+          """|package besom.api.kubernetes.crdk8samazonawscom.v1alpha1.inputs
+             |
+             |final case class EniConfigSpecArgs private(
+             |  securityGroups: besom.types.Output[scala.Option[scala.collection.immutable.List[String]]],
+             |  subnet: besom.types.Output[scala.Option[String]]
+             |)
+             |
+             |object EniConfigSpecArgs:
+             |  def apply(
+             |    securityGroups: besom.types.Input.Optional[scala.collection.immutable.List[besom.types.Input[String]]] = scala.None,
+             |    subnet: besom.types.Input.Optional[String] = scala.None
+             |  )(using besom.types.Context): EniConfigSpecArgs =
+             |    new EniConfigSpecArgs(
+             |      securityGroups = securityGroups.asOptionOutput(isSecret = false),
+             |      subnet = subnet.asOptionOutput(isSecret = false)
+             |    )
+             |
+             |  given encoder(using besom.types.Context): besom.types.Encoder[EniConfigSpecArgs] =
+             |    besom.internal.Encoder.derived[EniConfigSpecArgs]
+             |  given argsEncoder(using besom.types.Context): besom.types.ArgsEncoder[EniConfigSpecArgs] =
+             |    besom.internal.ArgsEncoder.derived[EniConfigSpecArgs]
+             |""".stripMargin
+      )
+    ),
+    Data(
       name = "Error on id property",
       json = """|{
                 |  "name": "fake-provider",

--- a/codegen/src/CodegenError.scala
+++ b/codegen/src/CodegenError.scala
@@ -7,8 +7,7 @@ sealed abstract class CodegenError(message: Option[String], cause: Option[Throwa
     with Serializable
 
 @SerialVersionUID(1L)
-case class GeneralCodegenException(message: Option[String], cause: Option[Throwable])
-    extends CodegenError(message, cause)
+case class GeneralCodegenException(message: Option[String], cause: Option[Throwable]) extends CodegenError(message, cause)
 object GeneralCodegenException {
   def apply(message: String)                   = new GeneralCodegenException(Some(message), None)
   def apply(message: String, cause: Throwable) = new GeneralCodegenException(Some(message), Some(cause))
@@ -16,8 +15,7 @@ object GeneralCodegenException {
 }
 
 @SerialVersionUID(1L)
-case class PulumiDefinitionCoordinatesError private (message: Option[String], cause: Option[Throwable])
-    extends CodegenError(message, cause)
+case class PulumiDefinitionCoordinatesError private (message: Option[String], cause: Option[Throwable]) extends CodegenError(message, cause)
 object PulumiDefinitionCoordinatesError {
   def apply(message: String)                   = new PulumiDefinitionCoordinatesError(Some(message), None)
   def apply(message: String, cause: Throwable) = new PulumiDefinitionCoordinatesError(Some(message), Some(cause))
@@ -25,8 +23,7 @@ object PulumiDefinitionCoordinatesError {
 }
 
 @SerialVersionUID(1L)
-case class ScalaDefinitionCoordinatesError(message: Option[String], cause: Option[Throwable])
-    extends CodegenError(message, cause)
+case class ScalaDefinitionCoordinatesError(message: Option[String], cause: Option[Throwable]) extends CodegenError(message, cause)
 object ScalaDefinitionCoordinatesError {
   def apply(message: String)                   = new ScalaDefinitionCoordinatesError(Some(message), None)
   def apply(message: String, cause: Throwable) = new ScalaDefinitionCoordinatesError(Some(message), Some(cause))
@@ -39,4 +36,24 @@ object TypeMapperError {
   def apply(message: String)                   = new TypeMapperError(Some(message), None)
   def apply(message: String, cause: Throwable) = new TypeMapperError(Some(message), Some(cause))
   def apply(cause: Throwable)                  = new TypeMapperError(None, Some(cause))
+}
+
+@SerialVersionUID(1L)
+case class AggregateCodegenError(message: Option[String], cause: Option[Throwable], errors: Seq[Throwable])
+    extends CodegenError(message, cause)
+    with Iterable[Throwable] {
+  def iterator: Iterator[Throwable] = errors.iterator
+
+  def +++(errors: Throwable*): AggregateCodegenError = AggregateCodegenError(errors ++ errors: _*)
+}
+object AggregateCodegenError {
+  def apply(errors: Throwable*): AggregateCodegenError = {
+    def message(t: Throwable) = s"[${t.getClass.getSimpleName}] '${Option(t.getMessage).getOrElse("no message")}'"
+    val msg                   = s"""Multiple Errors: ${errors.map(message).mkString(", ")}"""
+    val cause = errors.headOption.map { head =>
+      errors.foreach(head.addSuppressed)
+      head
+    }
+    new AggregateCodegenError(Some(msg), cause, errors)
+  }
 }

--- a/codegen/src/PulumiDefinitionCoordinates.scala
+++ b/codegen/src/PulumiDefinitionCoordinates.scala
@@ -72,6 +72,14 @@ case class PulumiDefinitionCoordinates private (
       definitionName = Some((methodPrefix.toSeq :+ mangleTypeName(methodName)).mkString("") + "Result")
     )
   }
+
+  def asConfigClass(implicit logger: Logger): ScalaDefinitionCoordinates = {
+    ScalaDefinitionCoordinates(
+      providerPackageParts = providerPackageParts,
+      modulePackageParts = modulePackageParts,
+      definitionName = Some(mangleTypeName(definitionName))
+    )
+  }
 }
 
 object PulumiDefinitionCoordinates {

--- a/codegen/src/PulumiDefinitionCoordinates.test.scala
+++ b/codegen/src/PulumiDefinitionCoordinates.test.scala
@@ -1,7 +1,7 @@
 package besom.codegen
 
 import besom.codegen.Config.ProviderConfig
-import besom.codegen.PackageMetadata.SchemaName
+import besom.codegen.SchemaName
 
 import scala.meta.*
 import scala.meta.dialects.Scala33

--- a/codegen/src/PulumiPackage.scala
+++ b/codegen/src/PulumiPackage.scala
@@ -89,10 +89,10 @@ object PulumiPackage {
           val indexEnd   = e.index + offset
           throw GeneralCodegenException(
             s"""|Cannot parse Pulumi package JSON schema: ${e.getMessage}
-              |JSON fragment [$indexStart, $indexEnd]]:
-              |...
-              |${input.slice(indexStart, indexEnd).stripLineEnd}
-              |...""".stripMargin,
+                |JSON fragment [$indexStart, $indexEnd]]:
+                |...
+                |${input.slice(indexStart, indexEnd).stripLineEnd}
+                |...""".stripMargin,
             e
           )
         case e: ujson.IncompleteParseException =>

--- a/codegen/src/PulumiPackage.scala
+++ b/codegen/src/PulumiPackage.scala
@@ -1,8 +1,8 @@
 package besom.codegen.metaschema
 
-import upickle.implicits.{key => fieldKey}
-import besom.codegen.{GeneralCodegenException, UpickleApi}
 import besom.codegen.UpickleApi.*
+import besom.codegen.{GeneralCodegenException, UpickleApi}
+import upickle.implicits.key as fieldKey
 
 /** PulumiPackage describes a Pulumi package.
   *
@@ -686,6 +686,8 @@ case class ObjectTypeDefinitionOrTypeReferenceProto(
 
 object ObjectTypeDefinitionOrTypeReferenceProto {
   implicit val reader: Reader[ObjectTypeDefinitionOrTypeReferenceProto] = macroR
+
+  def empty: ObjectTypeDefinitionOrTypeReferenceProto = ObjectTypeDefinitionOrTypeReferenceProto()
 }
 
 case class ObjectTypeDefinitionOrTypeReference(
@@ -697,7 +699,10 @@ object ObjectTypeDefinitionOrTypeReference {
   implicit val reader: Reader[ObjectTypeDefinitionOrTypeReference] =
     ObjectTypeDefinitionOrTypeReferenceProto.reader.map { proto =>
       val deserialized =
-        if (proto.properties.nonEmpty)
+        if proto == ObjectTypeDefinitionOrTypeReferenceProto.empty
+        then Some(empty)
+        else if proto.properties.nonEmpty
+        then
           proto.maybeAsObjectTypeDefinition.map(objectTypeDefinition =>
             ObjectTypeDefinitionOrTypeReference(objectTypeDefinition = Some(objectTypeDefinition), typeReference = None)
           )

--- a/codegen/src/PulumiPackageInfo.scala
+++ b/codegen/src/PulumiPackageInfo.scala
@@ -1,8 +1,7 @@
 package besom.codegen
 
-import besom.codegen.PackageMetadata.SchemaName
-import besom.codegen.PackageVersion
 import besom.codegen.metaschema.ConstValue
+import besom.codegen.{PackageVersion, SchemaName}
 
 type EnumInstanceName = String
 

--- a/codegen/src/ScalaDefinitionCoordinates.scala
+++ b/codegen/src/ScalaDefinitionCoordinates.scala
@@ -20,6 +20,7 @@ case class ScalaDefinitionCoordinates private (
     parts.toList
       .filterNot(_.isBlank)
       .map(_.replace("-", ""))
+      .map(_.replace(".", ""))
       .map(_.toLowerCase)
   }
 

--- a/codegen/src/SchemaProvider.scala
+++ b/codegen/src/SchemaProvider.scala
@@ -1,10 +1,9 @@
 package besom.codegen
 
-import besom.codegen.PackageMetadata.{SchemaFile, SchemaName}
-import besom.codegen.PackageVersion
 import besom.codegen.PackageVersion.PackageVersionOps
 import besom.codegen.Utils.PulumiPackageOps
 import besom.codegen.metaschema.*
+import besom.codegen.{PackageVersion, SchemaFile, SchemaName}
 
 import scala.collection.mutable.ListBuffer
 

--- a/codegen/src/TypeMapper.test.scala
+++ b/codegen/src/TypeMapper.test.scala
@@ -37,7 +37,7 @@ class TypeMapperTest extends munit.FunSuite {
     Data(
       UnionType(List(StringType, NamedType("#/types/aws:iam/role:Role")), Some(StringType)),
       metadata = PackageMetadata("aws", "6.7.0"),
-      tags = Set(munit.Slow, munit.Ignore)
+      tags = Set(munit.Slow)
     )(
       Expectations("String | besom.api.aws.iam.Role")
     ),

--- a/codegen/src/Utils.scala
+++ b/codegen/src/Utils.scala
@@ -11,7 +11,9 @@ object Utils {
   // Needs to be used in Pulumi types, but should NOT be translated to Scala code
   // Placeholder module for classes that should be in the root package (according to pulumi's convention)
   val indexModuleName  = "index"
+  val configModuleName = "config"
   val providerTypeName = "Provider"
+  val configTypeName   = "Config"
 
   // Name of the self parameter of resource methods
   val selfParameterName = "__self__"
@@ -31,6 +33,9 @@ object Utils {
   }
 
   implicit class TypeReferenceOps(typeRef: TypeReference) {
+    def asTokenAndDependency(implicit typeMapper: TypeMapper): Vector[(Option[PulumiToken], Option[PackageMetadata])] =
+      typeMapper.findTokenAndDependencies(typeRef)
+
     def asScalaType(asArgsType: Boolean = false)(implicit typeMapper: TypeMapper): Type =
       try {
         typeMapper.asScalaType(typeRef, asArgsType)
@@ -68,8 +73,9 @@ object Utils {
       module match {
         case _ if module.isEmpty =>
           throw TypeMapperError("Module cannot be empty")
-        case _ if module == indexModuleName => Seq(indexModuleName)
-        case moduleFormat(name)             => languageModuleToPackageParts(name)
+        case _ if module == indexModuleName  => Seq(indexModuleName)
+        case _ if module == configModuleName => Seq(configModuleName)
+        case moduleFormat(name)              => languageModuleToPackageParts(name)
         case _ =>
           throw TypeMapperError(
             s"Cannot parse module portion '$module' with moduleFormat: $moduleFormat"

--- a/codegen/src/scalameta.scala
+++ b/codegen/src/scalameta.scala
@@ -4,23 +4,43 @@ import scala.meta.*
 import scala.meta.dialects.Scala33
 
 object scalameta:
+  def parseStatement(code: String): Stat = code.parse[Stat].toEither match
+    case Left(error) => throw GeneralCodegenException(s"Failed to parse statement code:\n$code", error.details)
+    case Right(term) => term
+
+  def parseSource(code: String): Source = code.parse[Source].toEither match
+    case Left(error) => throw GeneralCodegenException(s"Failed to parse source code:\n$code", error.details)
+    case Right(term) => term
+
+  def given_(decltpe: Type)(body: Term): Defn.GivenAlias = Defn.GivenAlias(
+    mods = Nil,
+    name = Name.Anonymous(),
+    paramClauseGroup = scala.None,
+    decltpe = decltpe,
+    body = body
+  )
+
+  def apply_(qualType: Type.Name): Term.Ref             = apply_(Term.Name(qualType.value))
+  def apply_(qual: Term.Ref): Term.Ref                  = Term.Select(qual, Term.Name("apply"))
+  def method(qual: Term.Ref, name: String): Term.Ref    = method(qual, Term.Name(name))
+  def method(qual: Term.Ref, name: Term.Name): Term.Ref = Term.Select(qual, name)
 
   def ref(parts: String*): Term.Ref = ref(parts.toList)
   def ref(parts: List[String]): Term.Ref =
     parts.tail.foldLeft[Term.Ref](Term.Name(parts.head))((acc, name) => Term.Select(acc, Term.Name(name)))
 
-  val Unit: Term.Ref = Term.Select(Term.Name("scala"), Term.Name("Unit"))
-  val None: Term.Ref = Term.Select(Term.Name("scala"), Term.Name("None"))
-  val Some: Term.Ref = Term.Select(Term.Name("scala"), Term.Name("Some"))
-  val List: Term.Ref = Term.Select(ref("scala", "collection", "immutable"), Term.Name("List"))
-  def Some(value: Lit): Term.Apply = Term.Apply(Some, Term.ArgClause(value :: Nil))
+  val Unit: Term.Ref                        = Term.Select(Term.Name("scala"), Term.Name("Unit"))
+  val None: Term.Ref                        = Term.Select(Term.Name("scala"), Term.Name("None"))
+  val Some: Term.Ref                        = Term.Select(Term.Name("scala"), Term.Name("Some"))
+  val List: Term.Ref                        = Term.Select(ref("scala", "collection", "immutable"), Term.Name("List"))
+  def Some(value: Lit): Term.Apply          = Term.Apply(Some, Term.ArgClause(value :: Nil))
   def List(elements: List[Lit]): Term.Apply = Term.Apply(List, Term.ArgClause(elements))
-  def List(elements: Lit*): Term.Apply = List(elements.toList)
+  def List(elements: Lit*): Term.Apply      = List(elements.toList)
 
   object besom {
     object types {
       val Output: Term.Ref = Term.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Term.Name("Output"))
-      val Input: Term.Ref = Term.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Term.Name("Input"))
+      val Input: Term.Ref  = Term.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Term.Name("Input"))
 
       def Output(a: Term): Term.Apply = Term.Apply(Output, Term.ArgClause(a :: Nil))
 
@@ -40,13 +60,13 @@ object scalameta:
     private val Predef: Term.Ref = Term.Select(Term.Name("scala"), Term.Name("Predef"))
 
     val Boolean: Type.Ref = Type.Name("Boolean")
-    val String: Type.Ref = Type.Name("String")
-    val Int: Type.Ref = Type.Name("Int")
-    val Double: Type.Ref = Type.Name("Double")
-    val Unit: Type.Ref = Type.Select(Term.Name("scala"), Type.Name("Unit"))
-    val Option: Type.Ref = Type.Select(Term.Name("scala"), Type.Name("Option"))
-    val List: Type.Ref = Type.Select(ref("scala", "collection", "immutable"), Type.Name("List"))
-    val Map: Type.Ref = Type.Select(Predef, Type.Name("Map"))
+    val String: Type.Ref  = Type.Name("String")
+    val Int: Type.Ref     = Type.Name("Int")
+    val Double: Type.Ref  = Type.Name("Double")
+    val Unit: Type.Ref    = Type.Select(Term.Name("scala"), Type.Name("Unit"))
+    val Option: Type.Ref  = Type.Select(Term.Name("scala"), Type.Name("Option"))
+    val List: Type.Ref    = Type.Select(ref("scala", "collection", "immutable"), Type.Name("List"))
+    val Map: Type.Ref     = Type.Select(Predef, Type.Name("Map"))
 
     def Option(a: Type): Type.Apply = Type.Apply(Option, Type.ArgClause(a :: Nil))
 
@@ -57,7 +77,7 @@ object scalameta:
     def Map(v: Type): Type.Apply = Type.Apply(Map, Type.ArgClause(String :: v :: Nil))
 
     object besom {
-      //noinspection TypeAnnotation
+      // noinspection TypeAnnotation
       object types {
         val Context: Type.Ref = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("Context"))
 
@@ -70,23 +90,21 @@ object scalameta:
         def InputOptional(a: Type): Type =
           Type.Apply(Type.Select(Term.Select(ref("besom", "types"), Term.Name("Input")), Type.Name("Optional")), Type.ArgClause(a :: Nil))
 
-        val Archive = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("Archive"))
+        val Archive        = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("Archive"))
         val AssetOrArchive = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("AssetOrArchive"))
-        val PulumiAny = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("PulumiAny"))
-        val PulumiJson = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("PulumiJson"))
-        val URN = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("URN"))
-        val ResourceId = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("ResourceId"))
-        val BooleanEnum = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("BooleanEnum"))
-        val IntegerEnum = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("IntegerEnum"))
-        val NumberEnum = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("NumberEnum"))
-        val StringEnum = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("StringEnum"))
+        val PulumiAny      = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("PulumiAny"))
+        val PulumiJson     = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("PulumiJson"))
+        val URN            = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("URN"))
+        val ResourceId     = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("ResourceId"))
+        val BooleanEnum    = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("BooleanEnum"))
+        val IntegerEnum    = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("IntegerEnum"))
+        val NumberEnum     = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("NumberEnum"))
+        val StringEnum     = Type.Select(Term.Select(Term.Name("besom"), Term.Name("types")), Type.Name("StringEnum"))
       }
-    }
 
-    object spray {
       object json {
         def JsonFormat(a: Type): Type =
-          Type.Apply(Type.Select(Term.Select(Term.Name("spray"), Term.Name("json")), Type.Name("JsonFormat")), Type.ArgClause(a :: Nil))
+          Type.Apply(Type.Select(Term.Select(Term.Name("besom"), Term.Name("json")), Type.Name("JsonFormat")), Type.ArgClause(a :: Nil))
       }
     }
   }
@@ -107,4 +125,6 @@ object scalameta:
               throw GeneralCodegenException(s"Unexpected type '${o.getClass.getTypeName}' passed to Besom Scala Meta interpolator: '${o}'")
         }
 
-      def m(args: Any*): String = meta(args *)
+      def m(args: Any*): String = meta(args*)
+
+end scalameta

--- a/core/project.scala
+++ b/core/project.scala
@@ -1,6 +1,6 @@
 //> using scala "3.3.1"
 //> using options "-java-output-version:11", "-Ysafe-init", "-Xmax-inlines:64"
-//> using options "-Werror", "-Wunused:all", "-deprecation", "-feature"
+//> using options "-Werror", "-Wunused:all", "-deprecation", "-feature", -language:noAutoTupling
 
 //> using dep "org.virtuslab::besom-json:0.1.1-SNAPSHOT"
 

--- a/core/src/main/scala/besom/internal/Codegen.scala
+++ b/core/src/main/scala/besom/internal/Codegen.scala
@@ -1,0 +1,20 @@
+package besom.internal
+
+import besom.util.NonEmptyString
+import besom.json.DefaultJsonProtocol
+
+/** Used by the codegen module in the generated code.
+  */
+//noinspection ScalaUnusedSymbol
+object Codegen:
+  def config[A: ConfigValueReader](providerName: NonEmptyString)(
+    key: NonEmptyString,
+    isSecret: Boolean,
+    environment: List[String],
+    default: Option[A]
+  )(using Context): Output[Option[A]] = besom.Config(providerName).flatMap(_.getOrDefault(key, isSecret, environment, default))
+
+/** Used by the codegen module in the generated code.
+  */
+//noinspection ScalaUnusedSymbol
+object CodegenProtocol extends DefaultJsonProtocol

--- a/core/src/main/scala/besom/internal/ConfigValueReader.scala
+++ b/core/src/main/scala/besom/internal/ConfigValueReader.scala
@@ -1,5 +1,6 @@
 package besom.internal
 
+import besom.types.{BooleanEnum, EnumCompanion, IntegerEnum, NumberEnum, StringEnum}
 import besom.json.*
 
 import scala.util.Try
@@ -23,6 +24,14 @@ object ConfigValueReader:
   given jsonReader: ConfigValueReader[JsValue] with
     override def read(key: String, rawValue: String): Either[Exception, JsValue] =
       Try(rawValue.parseJson).toEither.left.map(e => ConfigError(s"Config value '$key' is not a valid JSON: $rawValue", e))
+  given stringEnumReader[E <: StringEnum, C <: EnumCompanion[String, E]](using ec: C): ConfigValueReader[E] with
+    override def read(key: String, rawValue: String): Either[Exception, E] = ec.fromValue(rawValue)
+  given booleanEnumReader[E <: BooleanEnum, C <: EnumCompanion[Boolean, E]](using ec: C): ConfigValueReader[E] with
+    override def read(key: String, rawValue: String): Either[Exception, E] = ec.fromValue(rawValue.toBoolean)
+  given intEnumReader[E <: IntegerEnum, C <: EnumCompanion[Int, E]](using ec: C): ConfigValueReader[E] with
+    override def read(key: String, rawValue: String): Either[Exception, E] = ec.fromValue(rawValue.toInt)
+  given doubleEnumReader[E <: NumberEnum, C <: EnumCompanion[Double, E]](using ec: C): ConfigValueReader[E] with
+    override def read(key: String, rawValue: String): Either[Exception, E] = ec.fromValue(rawValue.toDouble)
   given objectReader[A: JsonReader]: ConfigValueReader[A] with
     override def read(key: String, rawValue: String): Either[Exception, A] =
       Try(rawValue.parseJson.convertTo[A]).toEither.left.map(e =>

--- a/core/src/main/scala/besom/internal/codecs.scala
+++ b/core/src/main/scala/besom/internal/codecs.scala
@@ -169,7 +169,8 @@ object Decoder extends DecoderInstancesLowPrio1:
 
     override def mapping(value: Value, label: Label): Option[A] = ???
 
-  given unionIntStringDecoder: Decoder[Int | String] = unionDecoder[Int, String]
+  given unionIntStringDecoder: Decoder[Int | String]         = unionDecoder[Int, String]
+  given unionBooleanStringDecoder: Decoder[Boolean | String] = unionDecoder[Boolean, String]
 
   // this is kinda different from what other pulumi sdks are doing because we disallow nulls in the list
   given listDecoder[A](using innerDecoder: Decoder[A]): Decoder[List[A]] = new Decoder[List[A]]:

--- a/core/src/main/scala/besom/types.scala
+++ b/core/src/main/scala/besom/types.scala
@@ -1,13 +1,14 @@
 package besom
 
+import besom.internal.*
+import besom.internal.ProtobufUtil.*
+import besom.util.*
+import com.google.protobuf.struct.*
+
 import scala.compiletime.*
 import scala.compiletime.ops.string.*
 import scala.language.implicitConversions
 import scala.util.Try
-import com.google.protobuf.struct.*
-import besom.internal.ProtobufUtil.*
-import besom.util.*
-import besom.internal.*
 
 object types:
   // TODO: replace these stubs with proper implementations
@@ -328,7 +329,11 @@ object types:
 
   trait EnumCompanion[V, E <: PulumiEnum[V]](enumName: String):
     def allInstances: Seq[E]
-    private lazy val valuesToInstances: Map[Any, E] = allInstances.map(instance => instance.value -> instance).toMap
+    def fromValue(value: V): Either[Exception, E] = valuesToInstances.get(value).toRight(
+      left = Exception(s"`${value}` is not a valid value of `${enumName}`")
+    )
+
+    private lazy val valuesToInstances: Map[V, E] = allInstances.map(instance => instance.value -> instance).toMap
 
     extension [A](a: A)
       def asValueAny: Value = a match

--- a/core/src/main/scala/besom/util/Validated.scala
+++ b/core/src/main/scala/besom/util/Validated.scala
@@ -142,6 +142,8 @@ object Validated:
 
   object ValidatedResult:
     def apply[E, A](result: Result[Validated[E, A]]): ValidatedResult[E, A] = result
+    
+    def apply[E, A](validated: Validated[E, A]): ValidatedResult[E, A] = Result.pure(validated).asValidatedResult
 
     def valid[E, A](a: A): ValidatedResult[E, A] = Result.pure(Validated.valid(a))
 

--- a/core/src/test/scala/besom/internal/ConfigTest.scala
+++ b/core/src/test/scala/besom/internal/ConfigTest.scala
@@ -261,4 +261,18 @@ class ConfigTest extends munit.FunSuite {
     clue(outputData2)
     assertEquals(outputData2, OutputData(Some("bar")))
   }
+
+  testConfig("Codegen.config") (
+    configMap = Map("prov:names" -> """["a","b","c","super secret name"]"""),
+    configSecretKeys = Set.empty,
+    tested = Codegen.config[List[String]]("prov")(
+      key = "names",
+      isSecret = true,
+      environment = Nil,
+      default = None
+    )
+  ) { actual =>
+      val expected     = OutputData(Some(List("a", "b", "c", "super secret name")), isSecret = true)
+      assertEquals(actual, expected)
+  }
 }

--- a/core/src/test/scala/besom/internal/DecoderTest.scala
+++ b/core/src/test/scala/besom/internal/DecoderTest.scala
@@ -137,9 +137,114 @@ class DecoderTest extends munit.FunSuite:
     val d = summon[Decoder[SpecialCaseClass]]
 
     d.decode(v, dummyLabel).verify {
-      case Validated.Invalid(ex)                                   => throw ex.head
-      case Validated.Valid(OutputData.Known(res, isSecret, value)) => assert(value == Some(SpecialCaseClass(10, "abc", "qwerty")))
-      case Validated.Valid(_)                                      => throw Exception("Unexpected unknown!")
+      case Validated.Invalid(ex)                          => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) => assert(value == Some(SpecialCaseClass(10, "abc", "qwerty")))
+      case Validated.Valid(_)                             => throw Exception("Unexpected unknown!")
+    }
+  }
+
+  test("decode a generic union of 2") {
+    val v1 = Map(
+      "foo" -> 10.asValue,
+      "bar" -> List("qwerty".asValue).asValue,
+      "optNone1" -> Null,
+      "optSome" -> Some("abc").asValue
+    ).asValue
+    val v2 = Map(
+      "equals" -> 10.asValue,
+      "eq" -> "abc".asValue,
+      "normalOne" -> "qwerty".asValue
+    ).asValue
+
+    val d = unionDecoder2[TestCaseClass, SpecialCaseClass]
+    d.decode(v1, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(TestCaseClass(10, List("qwerty"), None, None, Some("abc"))))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+    d.decode(v2, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(SpecialCaseClass(10, "abc", "qwerty")))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+  }
+
+  test("decode a generic union of 3") {
+    val v1 = Map(
+      "foo" -> 10.asValue,
+      "bar" -> List("qwerty".asValue).asValue,
+      "optNone1" -> Null,
+      "optSome" -> Some("abc").asValue
+    ).asValue
+    val v2 = Map(
+      "equals" -> 10.asValue,
+      "eq" -> "abc".asValue,
+      "normalOne" -> "qwerty".asValue
+    ).asValue
+    val v3 = "A value".asValue
+
+    val d = unionDecoder3[TestCaseClass, SpecialCaseClass, TestEnum]
+    d.decode(v1, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(TestCaseClass(10, List("qwerty"), None, None, Some("abc"))))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+    d.decode(v2, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(SpecialCaseClass(10, "abc", "qwerty")))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+    d.decode(v3, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(TestEnum.A))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+  }
+
+  test("decode a generic union of 4") {
+    val v1 = Map(
+      "foo" -> 10.asValue,
+      "bar" -> List("qwerty".asValue).asValue,
+      "optNone1" -> Null,
+      "optSome" -> Some("abc").asValue
+    ).asValue
+    val v2 = Map(
+      "equals" -> 10.asValue,
+      "eq" -> "abc".asValue,
+      "normalOne" -> "qwerty".asValue
+    ).asValue
+    val v3 = "A value".asValue
+    val v4 = true.asValue
+
+    val d = unionDecoder4[TestCaseClass, SpecialCaseClass, TestEnum, Boolean]
+    d.decode(v1, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(TestCaseClass(10, List("qwerty"), None, None, Some("abc"))))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+    d.decode(v2, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(SpecialCaseClass(10, "abc", "qwerty")))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+    d.decode(v3, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(TestEnum.A))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
+    }
+    d.decode(v4, dummyLabel).verify {
+      case Validated.Invalid(ex) => throw ex.head
+      case Validated.Valid(OutputData.Known(_, _, value)) =>
+        assert(value == Some(true))
+      case Validated.Valid(_) => throw Exception("Unexpected unknown!")
     }
   }
 end DecoderTest

--- a/core/src/test/scala/besom/internal/DecoderTest.scala
+++ b/core/src/test/scala/besom/internal/DecoderTest.scala
@@ -100,6 +100,20 @@ class DecoderTest extends munit.FunSuite:
     }
   }
 
+  test("decode bool/string union") {
+    val d = summon[Decoder[Boolean | String]]
+    d.decode("A".asValue, dummyLabel).verify {
+      case Validated.Invalid(ex)                                   => throw ex.head
+      case Validated.Valid(OutputData.Known(res, isSecret, value)) => assert(value == Some("A"))
+      case Validated.Valid(_)                                      => throw Exception("Unexpected unknown!")
+    }
+    d.decode(true.asValue, dummyLabel).verify {
+      case Validated.Invalid(ex)                                   => throw ex.head
+      case Validated.Valid(OutputData.Known(res, isSecret, value)) => assert(value == Some(true))
+      case Validated.Valid(_)                                      => throw Exception("Unexpected unknown!")
+    }
+  }
+
   test("decode string/custom resource union") {
     val d = summon[Decoder[Int | String]]
     d.decode("A".asValue, dummyLabel).verify {

--- a/integration-tests/CodegenTests.test.scala
+++ b/integration-tests/CodegenTests.test.scala
@@ -1,7 +1,6 @@
 package besom.integration.codegen
 
 import besom.codegen.PackageMetadata
-import besom.codegen.PackageVersion
 import besom.integration.common.*
 import munit.{Slow, TestOptions}
 import os.*
@@ -35,13 +34,11 @@ class CodegenTests extends munit.FunSuite {
     "external-enum", // depends on google-native, TODO: check if this is still broken
     "enum-reference", // depends on google-native, TODO: check if this is still broken
     "hyphen-url", // depends on azure-native,
-    "naming-collisions", // codec not found
     "mini-azurenative", // decoder for union of 3 missing
     "cyclic-types", // YAML schema is not supported
-    "different-package-name-conflict", // duplicate issue
-    "output-funcs", // deserialize issue
+    "different-package-name-conflict", // file duplicate issue
+    "output-funcs", // union decoder issue
     "output-funcs-edgeorder", // missing union decoder issue
-    "other-owned" // codec not found
   )
 
   val tests =
@@ -73,9 +70,9 @@ class CodegenTests extends munit.FunSuite {
     test(options) {
       println(s"Test: $name")
       val result = codegen.generatePackageFromSchema(PackageMetadata(data.name), data.schema)
-      if (result.dependencies.nonEmpty)
-        println(s"\nCompiling dependencies for ${result.schemaName}...")
-      for (dep <- result.dependencies) {
+      if (result.metadata.dependencies.nonEmpty)
+        println(s"\nCompiling dependencies for ${result.metadata.name}...")
+      for (dep <- result.metadata.dependencies) {
         codegen.generateLocalPackage(dep)
       }
       println(s"\nCompiling generated code for ${data.name} in ${result.outputDir}...")
@@ -88,9 +85,5 @@ class CodegenTests extends munit.FunSuite {
       }
       println()
     }
-  }
-
-  override def beforeAll(): Unit = {
-    pproc("scala-cli", "bloop", "exit").call()
   }
 }

--- a/integration-tests/integration.scala
+++ b/integration-tests/integration.scala
@@ -244,11 +244,10 @@ object scalaCli {
     "compile",
     "--suppress-experimental-feature-warning",
     "--suppress-directives-in-multiple-files-warning",
-    "--jvm=17",
-    "--bloop-jvm=17",
-    "--bloop-java-opt=-XX:-UseZGC",
-    "--bloop-java-opt=-XX:+UseUseParallelGC",
-    "--bloop-java-opt=-XX:ParallelGCThreads=120",
+    "--server=false",
+    "--javac-opt=-verbose",
+    "--javac-opt=-J-XX:MaxHeapSize=32G",
+    "--javac-opt=-J-XX:+UseParallelGC",
     additional
   )
 
@@ -261,11 +260,10 @@ object scalaCli {
     "--doc=false",
     "--suppress-experimental-feature-warning",
     "--suppress-directives-in-multiple-files-warning",
-    "--jvm=17",
-    "--bloop-jvm=17",
-    "--bloop-java-opt=-XX:-UseZGC",
-    "--bloop-java-opt=-XX:+UseUseParallelGC",
-    "--bloop-java-opt=-XX:ParallelGCThreads=120",
+    "--server=false",
+    "--javac-opt=-verbose",
+    "--javac-opt=-J-XX:MaxHeapSize=32G",
+    "--javac-opt=-J-XX:+UseParallelGC",
     additional
   )
 }
@@ -278,9 +276,9 @@ object codegen {
   ): Unit = {
     val result = codegen.generatePackage(metadata)
     scalaCli.publishLocal(result.outputDir).call(check = false) // compilation will fail anyway
-    if (result.dependencies.nonEmpty)
-      println(s"\nCompiling dependencies for ${result.schemaName}:${result.packageVersion}...")
-    for (dep <- result.dependencies) {
+    if (result.metadata.dependencies.nonEmpty)
+      println(s"\nCompiling dependencies for ${result.metadata.name}:${result.metadata.version.getOrElse("none")}...")
+    for (dep <- result.metadata.dependencies) {
       generateLocalPackage(dep)
     }
   }


### PR DESCRIPTION
- add codegen for provider config (fixes #259)
- add resource references (fixes #144)
- fix dots in package segments in codegen
- fix deserialization of empty ObjectTypeDefinitionOrTypeReference
- resolve dependencies during package generation and publish
- disable bloop for packages
- use 32GB heap for package compilation
- uncomment two fixed codegen integration tests