### PR TITLE
Disallow nested arg Resource types in codegen's TypeMapper

### DIFF
--- a/codegen/src/PropertyInfo.test.scala
+++ b/codegen/src/PropertyInfo.test.scala
@@ -78,7 +78,6 @@ class PropertyInfoTest extends munit.FunSuite {
       expectedName = "restApi",
       expectedType = "String | besom.api.aws.apigateway.RestApi",
       metadata = PackageMetadata("aws", "6.7.0"),
-      tags = Set(munit.Ignore) // FIXME: https://github.com/VirtusLab/besom/issues/144
     ),
     Data(
       name = "property with external (downloaded) named type with duplicate object",

--- a/codegen/src/PulumiDefinitionCoordinates.scala
+++ b/codegen/src/PulumiDefinitionCoordinates.scala
@@ -21,7 +21,8 @@ case class PulumiDefinitionCoordinates private (
     )
   }
   def asObjectClass(asArgsType: Boolean)(implicit logger: Logger): ScalaDefinitionCoordinates = {
-    val packageSuffix = if (asArgsType) inputsPackage else outputsPackage
+    // because we have no plain inputs we can simplify and all Args are inputs
+    val packageSuffix = if asArgsType then inputsPackage else outputsPackage
     ScalaDefinitionCoordinates(
       providerPackageParts = providerPackageParts,
       modulePackageParts = modulePackageParts :+ packageSuffix,
@@ -32,8 +33,7 @@ case class PulumiDefinitionCoordinates private (
     ScalaDefinitionCoordinates(
       providerPackageParts = providerPackageParts,
       modulePackageParts = modulePackageParts :+ enumsPackage,
-      definitionName = Some(mangleTypeName(definitionName)),
-      isEnum = true
+      definitionName = Some(className(asArgsType = false))
     )
   }
 

--- a/codegen/src/ScalaDefinitionCoordinates.scala
+++ b/codegen/src/ScalaDefinitionCoordinates.scala
@@ -6,11 +6,10 @@ case class ScalaDefinitionCoordinates private (
   private val providerPackageParts: Seq[String],
   private val modulePackageParts: Seq[String],
   definitionName: Option[String],
-  selectionName: Option[String],
-  isEnum: Boolean
+  selectionName: Option[String]
 ) {
   import ScalaDefinitionCoordinates.*
-  
+
   def withSelectionName(selectionName: Option[String]): ScalaDefinitionCoordinates =
     copy(selectionName = selectionName)
 
@@ -91,8 +90,7 @@ object ScalaDefinitionCoordinates {
     providerPackageParts: Seq[String],
     modulePackageParts: Seq[String],
     definitionName: Option[String],
-    selectionName: Option[String] = None,
-    isEnum: Boolean = false // FIXME: refactor to use sealed trait
+    selectionName: Option[String] = None
   ): ScalaDefinitionCoordinates = {
     if definitionName.map(_.isBlank).getOrElse(false)
     then throw ScalaDefinitionCoordinatesError(s"Cannot create ScalaDefinitionCoordinates with blank definitionName: $definitionName")
@@ -100,8 +98,7 @@ object ScalaDefinitionCoordinates {
       providerPackageParts = providerPackageParts,
       modulePackageParts = modulePackageParts,
       definitionName = definitionName,
-      selectionName = selectionName,
-      isEnum = isEnum
+      selectionName = selectionName
     )
   }
 }


### PR DESCRIPTION
The assumption here is that we'll never propagate `Args` suffix to nested resource types.

Based on https://github.com/pulumi/pulumi/blob/16d9f4c1670404c2cb2f15d2dd095f05dc8eec12/pkg/codegen/nodejs/gen.go#L295

Fixes #144