### PR TITLE
Fix weird Output.sequence and Result.sequence problems

### DIFF
--- a/core/src/main/scala/besom/internal/Output.scala
+++ b/core/src/main/scala/besom/internal/Output.scala
@@ -119,12 +119,16 @@ object Output:
     Output {
       Result.defer {
         coll.iterator
-          .foldLeft(Output(bf.newBuilder(coll))) { (acc, curr) =>
-            acc.zip(curr).map { case (b, r) =>
-              b += r
+          .foldLeft(Output(Vector.empty[A])) { (acc, curr) =>
+            acc.zip(curr).map { case (vec, a) =>
+              vec :+ a
             }
           }
-          .map(_.result())
+          .map { vec =>
+            val b = bf.newBuilder(coll)
+            b.addAll(vec)
+            b.result()
+          }
       }
     }.flatten
 

--- a/core/src/main/scala/besom/internal/Result.scala
+++ b/core/src/main/scala/besom/internal/Result.scala
@@ -317,12 +317,16 @@ object Result:
     Result
       .defer {
         coll.iterator
-          .foldLeft(pure(bf.newBuilder(coll))) { (acc, curr) =>
-            acc.product(curr).map { case (b, r) =>
-              b += r
+          .foldLeft(pure(Vector.empty[A])) { (acc, curr) =>
+            acc.product(curr).map { case (vec, a) =>
+              vec :+ a
             }
           }
-          .map(_.result())
+          .map { vec =>
+            val b = bf.newBuilder(coll)
+            b.addAll(vec)
+            b.result()
+          }
       }
       .flatMap(identity)
 


### PR DESCRIPTION
hopefully this makes weird issues go away for good, it's still lazy but mutability should not pop up again (if that was mutability with concurrent access...)

for reference, the issue @pawelprazak encountered was: 
```
Diagnostics:
  pulumi:pulumi:Stack (aws-s3-folder-aws-s3-folder-dev):
    Compiling project (Scala 3.3.1, JVM (21))
    Compiled project (Scala 3.3.1, JVM (21))
    Exception in thread "main" java.lang.ClassCastException: class scala.collection.Iterator$$anon$9 cannot be cast to class scala.collection.Iterable (scala.collection.Iterator$$anon$9 and scala.collection.Iterable are in unnamed module of loader 'app')
        at scala.collection.BuildFromLowPriority2$$anon$11.newBuilder(BuildFrom.scala:109)
        at besom.internal.Output$.sequence$$anonfun$1$$anonfun$1(Output.scala:122)
        at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:678)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1423)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```
