### PR TITLE
Fix issue 397

### DIFF
--- a/core/src/main/scala/besom/internal/Context.scala
+++ b/core/src/main/scala/besom/internal/Context.scala
@@ -155,10 +155,10 @@ class ContextImpl(
     BesomMDC(Key.LabelKey, label) {
       Output.ofData {
         ResourceOps()
-          .readOrRegisterResourceInternal[R, EmptyArgs](
+          .readOrRegisterResourceInternal[R, A](
             typ,
             name,
-            EmptyArgs(),
+            args,
             options, // TODO pass initial ResourceTransformations here
             remote = true // all codegened components are remote components
           )

--- a/examples/kubernetes-guestbook/components/Main.scala
+++ b/examples/kubernetes-guestbook/components/Main.scala
@@ -18,8 +18,7 @@ case class ServiceDeploymentArgs(
   env: List[EnvVarArgs] = List.empty
 )
 
-case class ServiceDeployment(ipAddress: Output[Option[String]])(using ComponentBase) extends ComponentResource
-    derives RegistersOutputs
+case class ServiceDeployment(ipAddress: Output[Option[String]])(using ComponentBase) extends ComponentResource derives RegistersOutputs
 
 def serviceDeployment(using Context)(
   name: NonEmptyString,

--- a/examples/kubernetes-guestbook/simple/Main.scala
+++ b/examples/kubernetes-guestbook/simple/Main.scala
@@ -12,12 +12,12 @@ import besom.api.kubernetes.core.v1.enums.ServiceSpecType
   val isMinikube = config
     .getBoolean("isMinikube")
     .getOrElse(false)
-  
+
   //
   // REDIS LEADER.
   //
   val redisLeaderLabels = Map("app" -> "redis-leader")
-  val redisLeaderPort = 6379
+  val redisLeaderPort   = 6379
 
   val redisLeaderDeployment = Deployment(
     "redis-leader",
@@ -62,7 +62,7 @@ import besom.api.kubernetes.core.v1.enums.ServiceSpecType
   // REDIS REPLICA.
   //
   val redisReplicaLabels = Map("app" -> "redis-replica")
-  val redisReplicaPort = 6379
+  val redisReplicaPort   = 6379
 
   val redisReplicaDeployment = Deployment(
     "redis-replica",
@@ -110,7 +110,7 @@ import besom.api.kubernetes.core.v1.enums.ServiceSpecType
   // FRONTEND
   //
   val frontendLabels = Map("app" -> "frontend")
-  val frontendPort = 80
+  val frontendPort   = 80
 
   val frontendDeployment = Deployment(
     "frontend",


### PR DESCRIPTION
that was a dumb mistake really, copilot / copy-paste based prolly

Public / user-facing component API does not take any *Args so to reuse the internal functions it uses EmptyArgs with it's ArgsEncoder instance, this was copy-pasted in the rush of implementing remote components when RemoteComponents do actually take Args. The change is not binary-incompatible, just a patch version release should be enough.