### PR TITLE
Add overlay support to codegen

### DIFF
--- a/codegen/src/Logger.scala
+++ b/codegen/src/Logger.scala
@@ -2,7 +2,7 @@ package besom.codegen
 
 import scala.collection.mutable.ListBuffer
 
-class Logger(val printLevel: Logger.Level = Logger.Level.Info) {
+class Logger(val printLevel: Logger.Level) {
   import Logger.Level.*
 
   private val buffer     = ListBuffer.empty[String]
@@ -40,6 +40,8 @@ class Logger(val printLevel: Logger.Level = Logger.Level.Info) {
 }
 
 object Logger {
+  def apply()(using config: Config) = new Logger(config.logLevel)
+
   sealed abstract class Level(val level: Int) extends Ordered[Level] {
     override def compare(that: Level): Int = level.compare(that.level)
   }

--- a/codegen/src/Overlay.scala
+++ b/codegen/src/Overlay.scala
@@ -1,0 +1,20 @@
+package besom.codegen
+
+object Overlay:
+  def readFiles(
+    packageInfo: PulumiPackageInfo,
+    token: PulumiToken,
+    scalaDefinitions: Vector[ScalaDefinitionCoordinates]
+  )(using config: Config, logger: Logger): Vector[SourceFile] =
+    given Config.Provider = packageInfo.providerConfig
+
+    scalaDefinitions.flatMap { scalaDefinition =>
+      val relativeFilePath = scalaDefinition.filePath.copy(scalaDefinition.filePath.pathParts.tail) // drop "src" from the path
+      val path             = config.overlaysDir / packageInfo.name / relativeFilePath.osSubPath
+      if os.exists(path) then
+        val content = os.read(path)
+        Vector(SourceFile(scalaDefinition.filePath, content))
+      else
+        logger.info(s"Token '${token.asString}' was not generated because it was marked as overlay and not found at '${path}'")
+        Vector.empty
+    }

--- a/codegen/src/PackageMetadata.test.scala
+++ b/codegen/src/PackageMetadata.test.scala
@@ -45,8 +45,7 @@ class PackageMetadataTest extends munit.FunSuite {
 }
 
 class PackageVersionTest extends munit.FunSuite {
-
-  implicit val logger: Logger = new Logger
+  given Logger = new Logger(Logger.Level.Info)
 
   test("parse") {
     assertEquals(PackageVersion("v6.7.0").map(_.asString), Some("6.7.0"))

--- a/codegen/src/PulumiDefinitionCoordinates.scala
+++ b/codegen/src/PulumiDefinitionCoordinates.scala
@@ -47,7 +47,7 @@ case class PulumiDefinitionCoordinates private (
       case _ => throw PulumiDefinitionCoordinatesError(s"Invalid definition name '$definitionName'")
   }
 
-  def resourceMethod(implicit logger: Logger): ScalaDefinitionCoordinates = {
+  def asFunctionClass(using Logger): ScalaDefinitionCoordinates = {
     val (methodPrefix, methodName) = splitMethodName(definitionName)
     ScalaDefinitionCoordinates(
       providerPackageParts = providerPackageParts,
@@ -56,7 +56,7 @@ case class PulumiDefinitionCoordinates private (
       selectionName = Some(mangleMethodName(methodName))
     )
   }
-  def methodArgsClass(implicit logger: Logger): ScalaDefinitionCoordinates = {
+  def asFunctionArgsClass(using Logger): ScalaDefinitionCoordinates = {
     val (methodPrefix, methodName) = splitMethodName(definitionName)
     ScalaDefinitionCoordinates(
       providerPackageParts = providerPackageParts,
@@ -64,7 +64,7 @@ case class PulumiDefinitionCoordinates private (
       definitionName = Some((methodPrefix.toSeq :+ mangleTypeName(methodName)).mkString("") + "Args")
     )
   }
-  def methodResultClass(implicit logger: Logger): ScalaDefinitionCoordinates = {
+  def asFunctionResultClass(using Logger): ScalaDefinitionCoordinates = {
     val (methodPrefix, methodName) = splitMethodName(definitionName)
     ScalaDefinitionCoordinates(
       providerPackageParts = providerPackageParts,
@@ -73,7 +73,7 @@ case class PulumiDefinitionCoordinates private (
     )
   }
 
-  def asConfigClass(implicit logger: Logger): ScalaDefinitionCoordinates = {
+  def asConfigClass(using Logger): ScalaDefinitionCoordinates = {
     ScalaDefinitionCoordinates(
       providerPackageParts = providerPackageParts,
       modulePackageParts = modulePackageParts,

--- a/codegen/src/PulumiPackageInfo.scala
+++ b/codegen/src/PulumiPackageInfo.scala
@@ -1,20 +1,255 @@
 package besom.codegen
 
-import besom.codegen.metaschema.ConstValue
+import besom.codegen.Utils.{FunctionName, PulumiPackageOps, isMethod}
+import besom.codegen.metaschema.{FunctionDefinition, *}
 import besom.codegen.{PackageVersion, SchemaName}
+
+import scala.collection.mutable.ListBuffer
+import scala.util.matching.Regex
 
 type EnumInstanceName = String
 
 case class PulumiPackageInfo(
   name: SchemaName,
   version: PackageVersion,
-  enumTypeTokens: Set[String],
-  objectTypeTokens: Set[String],
   providerTypeToken: String,
-  resourceTypeTokens: Set[String],
   moduleToPackageParts: String => Seq[String],
   providerToPackageParts: String => Seq[String],
-  enumValueToInstances: Map[PulumiToken, Map[ConstValue, EnumInstanceName]]
+  enumTypeTokens: Set[String],
+  objectTypeTokens: Set[String],
+  resourceTypeTokens: Set[String],
+  enumValueToInstances: Map[PulumiToken, Map[ConstValue, EnumInstanceName]],
+  parsedTypes: Map[PulumiDefinitionCoordinates, (TypeDefinition, Boolean)],
+  parsedResources: Map[PulumiDefinitionCoordinates, (ResourceDefinition, Boolean)],
+  parsedFunctions: Map[PulumiDefinitionCoordinates, (FunctionDefinition, Boolean)]
+)(
+  private[codegen] val pulumiPackage: PulumiPackage,
+  private[codegen] val providerConfig: Config.Provider
 ) {
+  import PulumiPackageInfo.*
+
   def asPackageMetadata: PackageMetadata = PackageMetadata(name, Some(version))
+
+  def parseMethods(
+    resourceDefinition: ResourceDefinition
+  )(using logger: Logger): Map[FunctionName, (PulumiDefinitionCoordinates, (FunctionDefinition, Boolean))] = {
+    val (methods, notMethods) = resourceDefinition.methods.toSeq
+      .sortBy { case (name, _) => name }
+      .map { case (name, token) =>
+        (
+          name,
+          PulumiDefinitionCoordinates.fromRawToken(
+            typeToken = token,
+            moduleToPackageParts = moduleToPackageParts,
+            providerToPackageParts = providerToPackageParts
+          )
+        )
+      }
+      .map { case (name, definition) =>
+        (
+          name,
+          (
+            definition,
+            parsedFunctions.getOrElse(
+              definition,
+              throw TypeMapperError(
+                s"Function '${definition.token.asString}' defined as a resource method not found in package '${this.name}'"
+              )
+            )
+          )
+        )
+      }
+      .partition { case (_, (_, (d, _))) => isMethod(d) }
+
+    notMethods.foreach { case (token, _) =>
+      logger.info(s"Method '${token}' was not generated because it was not marked as method")
+    }
+    methods.toMap
+  }
+}
+
+object PulumiPackageInfo {
+  def from(
+    pulumiPackage: PulumiPackage,
+    packageMetadata: PackageMetadata
+  )(using Logger, Config): PulumiPackageInfo = PreProcessed.from(pulumiPackage, packageMetadata).process
+
+  private[PulumiPackageInfo] case class PreProcessed(
+    name: SchemaName,
+    version: PackageVersion,
+    moduleToPackageParts: String => Seq[String],
+    providerToPackageParts: String => Seq[String]
+  )(
+    private[codegen] val pulumiPackage: PulumiPackage,
+    private[codegen] val providerConfig: Config.Provider
+  ):
+    def parseResources: Map[PulumiDefinitionCoordinates, (ResourceDefinition, Boolean)] =
+      pulumiPackage.resources.map { case (token, resource) =>
+        val coordinates = PulumiDefinitionCoordinates.fromRawToken(
+          typeToken = token,
+          moduleToPackageParts = moduleToPackageParts,
+          providerToPackageParts = providerToPackageParts
+        )
+        (coordinates, (resource, resource.isOverlay))
+      }
+
+    def parseTypes(using Logger): Map[PulumiDefinitionCoordinates, (TypeDefinition, Boolean)] =
+      pulumiPackage.types.map { case (token, typeRef) =>
+        val coordinates = PulumiDefinitionCoordinates.fromRawToken(
+          typeToken = token,
+          moduleToPackageParts = moduleToPackageParts,
+          providerToPackageParts = providerToPackageParts
+        )
+        (coordinates, (typeRef, typeRef.isOverlay))
+      }
+
+    def parseFunctions(using Logger): Map[PulumiDefinitionCoordinates, (FunctionDefinition, Boolean)] =
+      pulumiPackage.functions.map { case (token, function) =>
+        val coordinates = PulumiDefinitionCoordinates.fromRawToken(
+          typeToken = token,
+          moduleToPackageParts = moduleToPackageParts,
+          providerToPackageParts = providerToPackageParts
+        )
+        (coordinates, (function, function.isOverlay))
+      }
+
+    def process(using logger: Logger): PulumiPackageInfo =
+      // pre-process the package to gather information about types, that are used later during various parts of codegen
+      // most notable place is TypeMapper.scalaTypeFromTypeUri
+      val enumTypeTokensBuffer     = ListBuffer.empty[String]
+      val objectTypeTokensBuffer   = ListBuffer.empty[String]
+      val resourceTypeTokensBuffer = ListBuffer.empty[String]
+
+      val enumValueToInstancesBuffer = ListBuffer.empty[(PulumiToken, Map[ConstValue, EnumInstanceName])]
+
+      def valueToInstances(enumDefinition: EnumTypeDefinition): Map[ConstValue, EnumInstanceName] =
+        enumDefinition.`enum`.map { (valueDefinition: EnumValueDefinition) =>
+          val caseRawName: EnumInstanceName = valueDefinition.name.getOrElse {
+            valueDefinition.value match {
+              case StringConstValue(value) => value
+              case const                   => throw GeneralCodegenException(s"The name of enum cannot be derived from value ${const}")
+            }
+          }
+          valueDefinition.value -> caseRawName
+        }.toMap
+
+      // Post-process the tokens to unify them to lower case to circumvent inconsistencies in low quality schemas (e.g. aws)
+      // This allows us to use case-insensitive matching when looking up tokens
+      val parsedTypes = parseTypes
+      parsedTypes.foreach {
+        case (coordinates, (definition: EnumTypeDefinition, _)) =>
+          enumValueToInstancesBuffer += coordinates.token -> valueToInstances(definition)
+
+          if (enumTypeTokensBuffer.contains(coordinates.token.asLookupKey))
+            logger.warn(s"Duplicate enum type token '${coordinates.token.asLookupKey}' in package '${name}'")
+          enumTypeTokensBuffer += coordinates.token.asLookupKey
+        case (coordinates, (_: ObjectTypeDefinition, _)) =>
+          if (objectTypeTokensBuffer.contains(coordinates.token.asLookupKey))
+            logger.warn(s"Duplicate object type token '${coordinates.token.asLookupKey}' in package '${name}'")
+          objectTypeTokensBuffer += coordinates.token.asLookupKey
+      }
+
+      val parsedResources = parseResources
+      parsedResources.foreach { case (coordinates, (_: ResourceDefinition, _)) =>
+        if (resourceTypeTokensBuffer.contains(coordinates.token.asLookupKey))
+          logger.warn(s"Duplicate resource type token '${coordinates.token.asLookupKey}' in package '${name}'")
+        resourceTypeTokensBuffer += coordinates.token.asLookupKey
+      }
+
+      PulumiPackageInfo(
+        name = name,
+        version = version,
+        providerTypeToken = s"pulumi:providers:${name}",
+        moduleToPackageParts = moduleToPackageParts,
+        providerToPackageParts = providerToPackageParts,
+        enumTypeTokens = enumTypeTokensBuffer.toSet,
+        objectTypeTokens = objectTypeTokensBuffer.toSet,
+        resourceTypeTokens = resourceTypeTokensBuffer.toSet,
+        enumValueToInstances = enumValueToInstancesBuffer.toMap,
+        parsedTypes = parsedTypes,
+        parsedResources = parsedResources,
+        parsedFunctions = parseFunctions
+      )(pulumiPackage, providerConfig)
+    end process
+  end PreProcessed
+  private[PulumiPackageInfo] object PreProcessed:
+    private[PulumiPackageInfo] def from(
+      pulumiPackage: PulumiPackage,
+      packageMetadata: PackageMetadata
+    )(using logger: Logger, config: Config): PreProcessed = {
+      val originalName = pulumiPackage.name
+      val overrideName = packageMetadata.name
+      if (originalName != overrideName) {
+        logger.warn(
+          s"Package name mismatch for '$overrideName' != '$originalName', " +
+            s"will be reconciled - this is fine in tests"
+        )
+      }
+      val originalVersion = PackageVersion(pulumiPackage.version).orDefault
+      val overrideVersion = packageMetadata.version.orDefault
+      if (originalVersion != overrideVersion) {
+        logger.warn(
+          s"Package version mismatch for '$overrideName:$overrideVersion' != '${originalVersion}', " +
+            s"will be reconciled - this is fine in tests"
+        )
+      }
+
+      val reconciledMetadata = pulumiPackage.toPackageMetadata(packageMetadata)
+      val providerConfig     = config.providers(reconciledMetadata.name)
+      val overrideModuleToPackages = providerConfig.moduleToPackages.view.mapValues { pkg =>
+        pkg.split("\\.").filter(_.nonEmpty).toSeq
+      }.toMap
+
+      PreProcessed(
+        name = reconciledMetadata.name,
+        version = reconciledMetadata.version.orDefault,
+        moduleToPackageParts = moduleToPackageParts(pulumiPackage, overrideModuleToPackages),
+        providerToPackageParts = providerToPackageParts
+      )(pulumiPackage, providerConfig)
+    }
+
+    // to get all of the package parts, first use the regexp provided by the schema
+    // then use a language specific mapping, and if everything fails, fallback to slash mapping
+    private def moduleToPackageParts(
+      pulumiPackage: PulumiPackage,
+      overrideModuleToPackages: Map[String, Seq[String]]
+    ): String => Seq[String] = { (module: String) =>
+      val moduleFormat: Regex = pulumiPackage.meta.moduleFormat.r
+      module match {
+        case _ if module.isEmpty =>
+          throw TypeMapperError("Module cannot be empty")
+        case _ if module == Utils.indexModuleName  => Seq(Utils.indexModuleName)
+        case _ if module == Utils.configModuleName => Seq(Utils.configModuleName)
+        case moduleFormat(name) => overrideModuleToPackages.withDefault(languageModuleToPackageParts(pulumiPackage))(name)
+        case _ =>
+          throw TypeMapperError(
+            s"Cannot parse module portion '$module' with moduleFormat: $moduleFormat"
+          )
+      }
+    }
+
+    def providerToPackageParts: String => Seq[String] = module => Seq(module)
+
+    private def languageModuleToPackageParts(pulumiPackage: PulumiPackage): String => Seq[String] = {
+      if (pulumiPackage.language.java.packages.view.nonEmpty) {
+        pulumiPackage.language.java.packages.view
+          .mapValues { pkg =>
+            pkg.split("\\.").filter(_.nonEmpty).toSeq
+          }
+          .toMap
+          .withDefault(slashModuleToPackageParts) // fallback to slash mapping
+      } else {
+        // use nodejs mapping as a fallback
+        pulumiPackage.language.nodejs.moduleToPackage.view
+          .mapValues { pkg =>
+            pkg.split("/").filter(_.nonEmpty).toSeq
+          }
+          .toMap
+          .withDefault(slashModuleToPackageParts) // fallback to slash mapping
+      }
+    }
+
+    private def slashModuleToPackageParts: String => Seq[String] =
+      pkg => pkg.split("/").filter(_.nonEmpty).toSeq
+  end PreProcessed
 }

--- a/codegen/src/PulumiToken.scala
+++ b/codegen/src/PulumiToken.scala
@@ -1,7 +1,5 @@
 package besom.codegen
 
-import besom.codegen.metaschema.PulumiPackage
-
 import scala.util.matching.Regex
 
 /** The parsed Pulumi type token used in Pulumi schema in a clean, canonical form, that enforces all three parts present
@@ -18,18 +16,16 @@ case class PulumiToken private (provider: String, module: String, name: String, 
   def asString: String = PulumiToken.concat(provider, module, name)
 
   /** Transform the Pulumi type token to a Pulumi definition coordinates
-    * @param pulumiPackage
+    * @param packageInfo
     *   the Pulumi package containing the schema information
     * @return
     *   the Pulumi definition coordinates for the given Pulumi type token
     */
-  def toCoordinates(pulumiPackage: PulumiPackage): PulumiDefinitionCoordinates = {
-    import besom.codegen.Utils.PulumiPackageOps
-
+  def toCoordinates(packageInfo: PulumiPackageInfo): PulumiDefinitionCoordinates = {
     PulumiDefinitionCoordinates.fromToken(
       typeToken = this,
-      moduleToPackageParts = pulumiPackage.moduleToPackageParts,
-      providerToPackageParts = pulumiPackage.providerToPackageParts
+      moduleToPackageParts = packageInfo.moduleToPackageParts,
+      providerToPackageParts = packageInfo.providerToPackageParts
     )
   }
 }

--- a/codegen/src/ScalaDefinitionCoordinates.scala
+++ b/codegen/src/ScalaDefinitionCoordinates.scala
@@ -64,12 +64,12 @@ case class ScalaDefinitionCoordinates private (
       )
   }
 
-  def filePath(implicit providerConfig: Config.ProviderConfig): FilePath = {
+  def filePath(using providerConfig: Config.Provider): FilePath = {
     // we DO NOT remove index from the file path, we add it if necessary
     val moduleParts = sanitizeParts(modulePackageParts) match {
       case moduleName :: tail =>
         // HACK: we need to exclude a module it does not compile
-        if (providerConfig.noncompiledModules.contains(moduleName)) {
+        if (providerConfig.nonCompiledModules.contains(moduleName)) {
           println(s"Excluding module: $moduleName")
           s".${moduleName}" +: tail // A leading dot excludes a directory from scala-cli sources
         } else {

--- a/codegen/src/ScalaDefinitionCoordinates.test.scala
+++ b/codegen/src/ScalaDefinitionCoordinates.test.scala
@@ -4,7 +4,6 @@ import scala.meta.*
 
 //noinspection ScalaFileName,TypeAnnotation
 class ScalaDefinitionCoordinatesTest extends munit.FunSuite {
-  implicit val providerConfig: Config.ProviderConfig = Config.ProviderConfig()
 
   case class Data(
     providerPackageParts: Seq[String],
@@ -56,6 +55,8 @@ class ScalaDefinitionCoordinatesTest extends munit.FunSuite {
 
   tests.foreach { data =>
     test(s"Type: ${data.definitionName}".withTags(data.tags.toSet)) {
+      given Config.Provider = Config().providers(data.providerPackageParts.head)
+
       val coords: ScalaDefinitionCoordinates = ScalaDefinitionCoordinates(
         providerPackageParts = data.providerPackageParts,
         modulePackageParts = data.modulePackageParts,

--- a/codegen/src/TypeMapper.scala
+++ b/codegen/src/TypeMapper.scala
@@ -7,9 +7,8 @@ import scala.meta.*
 import scala.meta.dialects.Scala33
 
 class TypeMapper(
-  val defaultPackageInfo: PulumiPackageInfo,
-  schemaProvider: SchemaProvider
-)(implicit logger: Logger) {
+  val defaultPackageInfo: PulumiPackageInfo
+)(using logger: Logger, schemaProvider: SchemaProvider) {
   import TypeMapper.*
 
   private def scalaTypeFromTypeUri(
@@ -34,14 +33,13 @@ class TypeMapper(
       case "" =>
         defaultPackageInfo
       case s"/${providerName}/v${schemaVersion}/schema.json" =>
-        schemaProvider.packageInfo(PackageMetadata(providerName, schemaVersion))._2
+        schemaProvider.packageInfo(PackageMetadata(providerName, schemaVersion))
       case s"${protocol}://${host}/${providerName}/v${schemaVersion}/schema.json" =>
         schemaProvider
           .packageInfo(
             PackageMetadata(providerName, schemaVersion)
               .withUrl(s"${protocol}://${host}/${providerName}")
           )
-          ._2
       case _ =>
         throw TypeMapperError(s"Unexpected file URI format: ${fileUri}")
     }

--- a/codegen/src/Utils.scala
+++ b/codegen/src/Utils.scala
@@ -3,7 +3,6 @@ package besom.codegen
 import besom.codegen.metaschema.*
 
 import scala.meta.{Lit, Type}
-import scala.util.matching.Regex
 
 object Utils {
   // "index" is a placeholder module for classes that should be in
@@ -21,7 +20,8 @@ object Utils {
   // TODO: Find some workaround to enable passing the remaining arguments
   val jvmMaxParamsCount = 253 // https://github.com/scala/bug/issues/7324
 
-  type FunctionName = String
+  type FunctionName  = String
+  type FunctionToken = String
 
   implicit class ConstValueOps(constValue: ConstValue) {
     def asScala: Lit = constValue match {
@@ -33,10 +33,10 @@ object Utils {
   }
 
   implicit class TypeReferenceOps(typeRef: TypeReference) {
-    def asTokenAndDependency(implicit typeMapper: TypeMapper): Vector[(Option[PulumiToken], Option[PackageMetadata])] =
+    def asTokenAndDependency(using typeMapper: TypeMapper): Vector[(Option[PulumiToken], Option[PackageMetadata])] =
       typeMapper.findTokenAndDependencies(typeRef)
 
-    def asScalaType(asArgsType: Boolean = false)(implicit typeMapper: TypeMapper): Type =
+    def asScalaType(asArgsType: Boolean = false)(using typeMapper: TypeMapper): Type =
       try {
         typeMapper.asScalaType(typeRef, asArgsType)
       } catch {
@@ -46,138 +46,13 @@ object Utils {
   }
 
   implicit class PulumiPackageOps(pulumiPackage: PulumiPackage) {
-    private def slashModuleToPackageParts: String => Seq[String] =
-      pkg => pkg.split("/").filter(_.nonEmpty).toSeq
-
-    private def languageModuleToPackageParts: String => Seq[String] = {
-      if (pulumiPackage.language.java.packages.view.nonEmpty) {
-        pulumiPackage.language.java.packages.view
-          .mapValues { pkg =>
-            pkg.split("\\.").filter(_.nonEmpty).toSeq
-          }
-          .toMap
-          .withDefault(slashModuleToPackageParts) // fallback to slash mapping
-      } else {
-        // use nodejs mapping as a fallback
-        pulumiPackage.language.nodejs.moduleToPackage.view
-          .mapValues { pkg =>
-            pkg.split("/").filter(_.nonEmpty).toSeq
-          }
-          .toMap
-          .withDefault(slashModuleToPackageParts) // fallback to slash mapping
-      }
-    }
-
-    private def packageFormatModuleToPackageParts: String => Seq[String] = { (module: String) =>
-      val moduleFormat: Regex = pulumiPackage.meta.moduleFormat.r
-      module match {
-        case _ if module.isEmpty =>
-          throw TypeMapperError("Module cannot be empty")
-        case _ if module == indexModuleName  => Seq(indexModuleName)
-        case _ if module == configModuleName => Seq(configModuleName)
-        case moduleFormat(name)              => languageModuleToPackageParts(name)
-        case _ =>
-          throw TypeMapperError(
-            s"Cannot parse module portion '$module' with moduleFormat: $moduleFormat"
-          )
-      }
-    }
-
-    // to get all of the package parts, first use the regexp provided by the schema
-    // then use a language specific mapping, and if everything fails, fallback to slash mapping
-    def moduleToPackageParts: String => Seq[String]   = packageFormatModuleToPackageParts
-    def providerToPackageParts: String => Seq[String] = module => Seq(module)
-
-    def providerTypeToken: String = s"pulumi:providers:${pulumiPackage.name}"
-
     def toPackageMetadata(overrideMetadata: PackageMetadata): PackageMetadata =
       toPackageMetadata(Some(overrideMetadata))
     def toPackageMetadata(overrideMetadata: Option[PackageMetadata] = None): PackageMetadata = {
-      import PackageVersion.*
       overrideMetadata match {
         case Some(d) => PackageMetadata(d.name, PackageVersion(pulumiPackage.version).reconcile(d.version))
         case None    => PackageMetadata(pulumiPackage.name, PackageVersion(pulumiPackage.version))
       }
-    }
-
-    type FunctionToken = String
-
-    private[Utils] def nonOverlayFunctions(implicit logger: Logger): Map[FunctionToken, FunctionDefinition] = {
-      val (overlays, functions) = pulumiPackage.functions.partition { case (_, d) => d.isOverlay }
-      overlays.foreach { case (token, _) =>
-        logger.info(s"Function '${token}' was not generated because it was marked as overlay")
-      }
-      functions
-    }
-
-    def parsedFunctions(implicit logger: Logger): Map[PulumiDefinitionCoordinates, FunctionDefinition] = {
-      nonOverlayFunctions.map { case (token, function) =>
-        val coordinates = PulumiDefinitionCoordinates.fromRawToken(
-          typeToken = token,
-          moduleToPackageParts = moduleToPackageParts,
-          providerToPackageParts = providerToPackageParts
-        )
-        (coordinates, function)
-      }
-    }
-
-    def parsedTypes(implicit logger: Logger): Map[PulumiDefinitionCoordinates, TypeDefinition] = {
-      val (overlays, types) = pulumiPackage.types.partition { case (_, d) => d.isOverlay }
-      overlays.foreach { case (token, _) =>
-        logger.info(s"Type '${token}' was not generated because it was marked as overlay")
-      }
-      types.collect { case (token, typeRef) =>
-        val coordinates = PulumiDefinitionCoordinates.fromRawToken(
-          typeToken = token,
-          moduleToPackageParts = moduleToPackageParts,
-          providerToPackageParts = providerToPackageParts
-        )
-        (coordinates, typeRef)
-      }
-    }
-
-    def parsedResources(implicit logger: Logger): Map[PulumiDefinitionCoordinates, ResourceDefinition] = {
-      val (overlays, resources) = pulumiPackage.resources.partition { case (_, d) => d.isOverlay }
-      overlays.foreach { case (token, _) =>
-        logger.info(s"Resource '${token}' was not generated because it was marked as overlay")
-      }
-      resources.collect { case (token, resource) =>
-        val coordinates = PulumiDefinitionCoordinates.fromRawToken(
-          typeToken = token,
-          moduleToPackageParts = moduleToPackageParts,
-          providerToPackageParts = providerToPackageParts
-        )
-        (coordinates, resource)
-      }
-    }
-
-    def parsedMethods(
-      resourceDefinition: ResourceDefinition
-    )(implicit logger: Logger): Map[FunctionName, (PulumiDefinitionCoordinates, FunctionDefinition)] = {
-      val (methods, notMethods) = resourceDefinition.methods.toSeq
-        .sortBy { case (name, _) => name }
-        .map { case (name, token) =>
-          (
-            name,
-            (
-              PulumiDefinitionCoordinates.fromRawToken(
-                typeToken = token,
-                moduleToPackageParts = pulumiPackage.moduleToPackageParts,
-                providerToPackageParts = pulumiPackage.providerToPackageParts
-              ),
-              pulumiPackage.nonOverlayFunctions.getOrElse(
-                token,
-                throw TypeMapperError(s"Function '${token}' not found in package '${pulumiPackage.name}'")
-              )
-            )
-          )
-        }
-        .partition { case (_, (_, d)) => isMethod(d) }
-
-      notMethods.foreach { case (token, _) =>
-        logger.info(s"Method '${token}' was not generated because it was not marked as method")
-      }
-      methods.toMap
     }
   }
 

--- a/integration-tests/CoreTests.test.scala
+++ b/integration-tests/CoreTests.test.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.*
 class CoreTests extends munit.FunSuite {
   override val munitTimeout = 5.minutes
 
-  implicit val codegenConfig: Config.CodegenConfig = Config.CodegenConfig()
+  given config: Config = Config()
 
   val wd = os.pwd / "integration-tests"
 

--- a/integration-tests/integration.scala
+++ b/integration-tests/integration.scala
@@ -1,6 +1,5 @@
 package besom.integration.common
 
-import besom.codegen.Config.CodegenConfig
 import besom.codegen.generator.Result
 import besom.codegen.{Config, PackageMetadata}
 import munit.{Tag, Test}
@@ -303,8 +302,7 @@ object codegen {
     metadata: PackageMetadata,
     outputDir: Option[os.RelPath] = None
   ): generator.Result = {
-    // noinspection TypeAnnotation
-    implicit val config = CodegenConfig(outputDir = outputDir)
+    given Config = Config(outputDir = outputDir)
     generator.generatePackageSources(metadata)
   }
 
@@ -313,8 +311,7 @@ object codegen {
     schema: os.Path,
     outputDir: Option[os.RelPath] = None
   ): generator.Result = {
-    // noinspection TypeAnnotation
-    implicit val config = CodegenConfig(outputDir = outputDir)
+    given Config = Config(outputDir = outputDir)
     generator.generatePackageSources(metadata, Some(schema))
   }
 }

--- a/scripts/Packages.scala
+++ b/scripts/Packages.scala
@@ -1,7 +1,6 @@
 package besom.scripts
 
 import besom.codegen.*
-import besom.codegen.Config.CodegenConfig
 import besom.model.SemanticVersion
 import coursier.error.ResolutionError.CantDownloadModule
 import org.virtuslab.yaml.*
@@ -295,7 +294,7 @@ object Packages:
           val versionOrLatest = m.version.getOrElse("latest")
           Progress.report(label = s"${m.name}:${versionOrLatest}")
           try
-            implicit val codegenConfig: CodegenConfig = CodegenConfig(
+            given Config = Config(
               schemasDir = schemasDir,
               codegenDir = codegenDir
             )


### PR DESCRIPTION
- refactor codegen to allow for the required changes to be made
  - `implicit val` changed to `given`/`using`
  - unified `Config` with added overlays dir setting (`overlaysDir`/`DefaultOverlaysDir`)
  - pre-process the schema and store parsed types, resources and functions in `PulumiPackageInfo`
  - store a reference to the deserialized schema in the `PulumiPackageInfo`
  - store provider related config (e.g. overlays) per schema in the `PulumiPackageInfo`
  - parsing logic moved from `SchemaProvider` and `PulumiPackageOps` to `PulumiPackageInfo`
  - other small cosmetic changes, renames, etc
- add support for overlays in codegen (`Overlay.scala`)

fixes #286 (was closed as done, but we were just ignoring the overlays, now we can add them)
