### PR TITLE
Json handling improvements

### DIFF
--- a/besom-json/src/main/scala/besom/json/JsonFormat.scala
+++ b/besom-json/src/main/scala/besom/json/JsonFormat.scala
@@ -31,6 +31,8 @@ object JsonReader {
   implicit def func2Reader[T](f: JsValue => T): JsonReader[T] = new JsonReader[T] {
     def read(json: JsValue) = f(json)
   }
+
+  inline def derived[T <: Product](using JsonProtocol): JsonReader[T] = summon[JsonProtocol].jsonFormatN[T]
 }
 
 /** Provides the JSON serialization for type T.
@@ -44,6 +46,8 @@ object JsonWriter {
   implicit def func2Writer[T](f: T => JsValue): JsonWriter[T] = new JsonWriter[T] {
     def write(obj: T) = f(obj)
   }
+
+  inline def derived[T <: Product](using JsonProtocol): JsonWriter[T] = summon[JsonProtocol].jsonFormatN[T]
 }
 
 /** Provides the JSON deserialization and serialization for type T.
@@ -51,7 +55,7 @@ object JsonWriter {
 trait JsonFormat[T] extends JsonReader[T] with JsonWriter[T]
 
 object JsonFormat:
-  inline def derived[T <: Product](using JsonProtocol) = summon[JsonProtocol].jsonFormatN[T]
+  inline def derived[T <: Product](using JsonProtocol): JsonFormat[T] = summon[JsonProtocol].jsonFormatN[T]
 
 /** A special JsonReader capable of reading a legal JSON root object, i.e. either a JSON array or a JSON object.
   */

--- a/besom-json/src/main/scala/besom/json/ProductFormats.scala
+++ b/besom-json/src/main/scala/besom/json/ProductFormats.scala
@@ -27,6 +27,35 @@ object ProductFormatsMacro:
   import scala.deriving.*
   import scala.quoted.*
 
+  private def findDefaultParams[T](using quotes: Quotes, tpe: Type[T]): Expr[Map[String, Any]] =
+    import quotes.reflect.*
+
+    TypeRepr.of[T].classSymbol match
+      case None => '{ Map.empty[String, Any] }
+      case Some(sym) =>
+        val comp = sym.companionClass
+        try
+          val mod = Ref(sym.companionModule)
+          val names =
+            for p <- sym.caseFields if p.flags.is(Flags.HasDefault)
+            yield p.name
+          val namesExpr: Expr[List[String]] =
+            Expr.ofList(names.map(Expr(_)))
+
+          val body = comp.tree.asInstanceOf[ClassDef].body
+          val idents: List[Ref] =
+            for
+              case deff @ DefDef(name, _, _, _) <- body
+              if name.startsWith("$lessinit$greater$default")
+            yield mod.select(deff.symbol)
+          val typeArgs = TypeRepr.of[T].typeArgs
+          val identsExpr: Expr[List[Any]] =
+            if typeArgs.isEmpty then Expr.ofList(idents.map(_.asExpr))
+            else Expr.ofList(idents.map(_.appliedToTypes(typeArgs).asExpr))
+
+          '{ $namesExpr.zip($identsExpr).toMap }
+        catch case cce: ClassCastException => '{ Map.empty[String, Any] } // TODO drop after https://github.com/lampepfl/dotty/issues/19732
+
   def jsonFormatImpl[T <: Product: Type](prodFormats: Expr[ProductFormats])(using Quotes): Expr[RootJsonFormat[T]] =
     Expr.summon[Mirror.Of[T]].get match
       case '{
@@ -50,25 +79,26 @@ object ProductFormatsMacro:
 
         // instances are in correct order of fields of the product
         val allInstancesExpr = Expr.ofList(prepareInstances(Type.of[elementLabels], Type.of[elementTypes]))
+        val defaultArguments = findDefaultParams[T]
 
         '{
           new RootJsonFormat[T]:
             private val allInstances = ${ allInstancesExpr }
             private val fmts         = ${ prodFormats }
+            private val defaultArgs  = ${ defaultArguments }
+
             def read(json: JsValue): T = json match
               case JsObject(fields) =>
                 val values = allInstances.map { case (fieldName, fieldFormat, isOption) =>
-                  val fieldValue =
-                    try fieldFormat.read(fields(fieldName))
-                    catch
-                      case e: NoSuchElementException =>
-                        if isOption then None
-                        else
-                          throw DeserializationException("Object is missing required member '" ++ fieldName ++ "'", null, fieldName :: Nil)
-                      case DeserializationException(msg, cause, fieldNames) =>
-                        throw DeserializationException(msg, cause, fieldName :: fieldNames)
-
-                  fieldValue
+                  try fieldFormat.read(fields(fieldName))
+                  catch
+                    case e: NoSuchElementException =>
+                      if isOption then
+                        if defaultArgs.contains(fieldName) then defaultArgs(fieldName)
+                        else None
+                      else throw DeserializationException("Object is missing required member '" ++ fieldName ++ "'", null, fieldName :: Nil)
+                    case DeserializationException(msg, cause, fieldNames) =>
+                      throw DeserializationException(msg, cause, fieldName :: fieldNames)
                 }
                 $m.fromProduct(Tuple.fromArray(values.toArray))
 

--- a/besom-json/src/main/scala/besom/json/package.scala
+++ b/besom-json/src/main/scala/besom/json/package.scala
@@ -45,12 +45,11 @@ private[json] trait DefaultExports:
   implicit def enrichAny[T](any: T): RichAny[T]         = new RichAny(any)
   implicit def enrichString(string: String): RichString = new RichString(string)
 
-object DefaultJsonExports extends DefaultExports
+private[json] trait DefaultProtocol:
+  implicit val defaultProtocol: JsonProtocol = DefaultJsonProtocol
 
-export DefaultJsonExports.*
-
-/** This allows to perform a single import: `import besom.json.default.*` to get basic JSON behaviour. If you need to extend JSON handling
-  * in any way, please use `import besom.json.*`, then extend `DefaultJsonProtocol`:
+/** This allows to perform a single import: `import besom.json.*` to get basic JSON behaviour. If you need to extend JSON handling in any
+  * way, please use `import besom.json.custom.*`, then extend `DefaultJsonProtocol`:
   *
   * ```
   *   object MyCustomJsonProtocol extends DefaultJsonProtocol:
@@ -63,8 +62,14 @@ export DefaultJsonExports.*
   *   case class MyCaseClass(a: String, b: Int) derives JsonFormat
   * ```
   */
-object default:
-  export DefaultJsonExports.*
-  export DefaultJsonProtocol.*
+object custom extends DefaultExports:
+  export besom.json.{JsonProtocol, DefaultJsonProtocol}
+  export besom.json.{JsonFormat, JsonReader, JsonWriter}
+  export besom.json.{RootJsonFormat, RootJsonReader, RootJsonWriter}
+  export besom.json.{DeserializationException, SerializationException}
+  export besom.json.{JsValue, JsObject, JsArray, JsString, JsNumber, JsBoolean, JsNull}
 
-  implicit val defaultProtocol: JsonProtocol = DefaultJsonProtocol
+object DefaultJsonExports extends DefaultExports with DefaultProtocol
+
+export DefaultJsonExports.*
+export DefaultJsonProtocol.*

--- a/besom-json/src/main/scala/besom/json/package.scala
+++ b/besom-json/src/main/scala/besom/json/package.scala
@@ -50,7 +50,7 @@ object DefaultJsonExports extends DefaultExports
 export DefaultJsonExports.*
 
 /** This allows to perform a single import: `import besom.json.default.*` to get basic JSON behaviour. If you need to extend JSON handling
-  * in any way, please perfom `import besom.json.*`, then extend `DefaultJsonProtocol`:
+  * in any way, please use `import besom.json.*`, then extend `DefaultJsonProtocol`:
   *
   * ```
   *   object MyCustomJsonProtocol extends DefaultJsonProtocol:

--- a/besom-json/src/test/scala/besom/json/DerivedFormatsSpec.scala
+++ b/besom-json/src/test/scala/besom/json/DerivedFormatsSpec.scala
@@ -1,4 +1,4 @@
-package besom.json
+package besom.json.test
 
 import org.specs2.mutable.*
 
@@ -6,12 +6,80 @@ class DerivedFormatsSpec extends Specification {
 
   "The derives keyword" should {
     "behave as expected" in {
-      import besom.json.default.*
+      import besom.json.*
 
       case class Color(name: String, red: Int, green: Int, blue: Int) derives JsonFormat
       val color = Color("CadetBlue", 95, 158, 160)
 
       color.toJson.convertTo[Color] mustEqual color
+    }
+
+    "be able to support default argument values" in {
+      import besom.json.*
+
+      case class Color(name: String, red: Int, green: Int, blue: Option[Int] = Some(255)) derives JsonFormat
+      val color = Color("CadetBlue", 95, 158)
+
+      val json = """{"name":"CadetBlue","red":95,"green":158}"""
+
+      color.toJson.convertTo[Color] mustEqual color
+      json.parseJson.convertTo[Color] mustEqual color
+    }
+
+    "be able to support missing fields when there are default argument values" in {
+      import besom.json.*
+
+      case class Color(name: String, red: Int, green: Int, blue: Option[Int] = None) derives JsonFormat
+      val color = Color("CadetBlue", 95, 158)
+
+      val json = """{"green":158,"red":95,"name":"CadetBlue"}"""
+
+      color.toJson.compactPrint mustEqual json
+      color.toJson.convertTo[Color] mustEqual color
+      json.parseJson.convertTo[Color] mustEqual color
+    }
+
+    "be able to write and read nulls for optional fields" in {
+      import besom.json.custom.*
+
+      locally {
+        given jp: JsonProtocol = new DefaultJsonProtocol {
+          override def writeNulls             = true
+          override def requireNullsForOptions = true
+        }
+        import jp.*
+
+        case class Color(name: String, red: Int, green: Int, blue: Option[Int]) derives JsonFormat
+        val color = Color("CadetBlue", 95, 158, None)
+
+        val json = """{"blue":null,"green":158,"red":95,"name":"CadetBlue"}"""
+
+        color.toJson.compactPrint mustEqual json
+
+        color.toJson.convertTo[Color] mustEqual color
+        json.parseJson.convertTo[Color] mustEqual color
+
+        val noExplicitNullJson = """{"green":158,"red":95,"name":"CadetBlue"}"""
+        noExplicitNullJson.parseJson.convertTo[Color] must throwA[DeserializationException]
+      }
+
+      locally {
+        given jp2: JsonProtocol = new DefaultJsonProtocol {
+          override def writeNulls             = false
+          override def requireNullsForOptions = false
+        }
+        import jp2.*
+
+        case class Color(name: String, red: Int, green: Int, blue: Option[Int]) derives JsonFormat
+        val color = Color("CadetBlue", 95, 158, None)
+
+        val json = """{"green":158,"red":95,"name":"CadetBlue"}"""
+
+        color.toJson.compactPrint mustEqual json
+
+        color.toJson.convertTo[Color] mustEqual color
+        json.parseJson.convertTo[Color] mustEqual color
+      }
     }
   }
 }

--- a/besom-json/src/test/scala/besom/json/DerivedFormatsSpec.scala
+++ b/besom-json/src/test/scala/besom/json/DerivedFormatsSpec.scala
@@ -17,7 +17,7 @@ class DerivedFormatsSpec extends Specification {
     "be able to support default argument values" in {
       import besom.json.*
 
-      case class Color(name: String, red: Int, green: Int, blue: Option[Int] = Some(255)) derives JsonFormat
+      case class Color(name: String, red: Int, green: Int, blue: Int = 160) derives JsonFormat
       val color = Color("CadetBlue", 95, 158)
 
       val json = """{"name":"CadetBlue","red":95,"green":158}"""

--- a/besom-json/src/test/scala/besom/json/DerivedFormatsSpec.scala
+++ b/besom-json/src/test/scala/besom/json/DerivedFormatsSpec.scala
@@ -6,8 +6,7 @@ class DerivedFormatsSpec extends Specification {
 
   "The derives keyword" should {
     "behave as expected" in {
-      import DefaultJsonProtocol.*
-      given JsonProtocol = DefaultJsonProtocol
+      import besom.json.default.*
 
       case class Color(name: String, red: Int, green: Int, blue: Int) derives JsonFormat
       val color = Color("CadetBlue", 95, 158, 160)

--- a/core/src/main/scala/besom/internal/Env.scala
+++ b/core/src/main/scala/besom/internal/Env.scala
@@ -43,7 +43,7 @@ object Env:
   private[internal] def getMaybe(key: String): Option[NonEmptyString] =
     sys.env.get(key).flatMap(NonEmptyString(_))
 
-  import besom.json.*, DefaultJsonProtocol.*
+  import besom.json.*
 
   given nesJF(using jfs: JsonFormat[String]): JsonFormat[NonEmptyString] =
     new JsonFormat[NonEmptyString]:

--- a/core/src/main/scala/besom/json/custom/interpolator.scala
+++ b/core/src/main/scala/besom/json/custom/interpolator.scala
@@ -1,0 +1,3 @@
+package besom.json.custom
+
+export besom.util.JsonInterpolator.*

--- a/core/src/main/scala/besom/json/custom/interpolator.scala
+++ b/core/src/main/scala/besom/json/custom/interpolator.scala
@@ -1,3 +1,0 @@
-package besom.json.custom
-
-export besom.util.JsonInterpolator.*

--- a/core/src/main/scala/besom/json/interpolator.scala
+++ b/core/src/main/scala/besom/json/interpolator.scala
@@ -1,0 +1,3 @@
+package besom.json
+
+export besom.util.JsonInterpolator.*

--- a/core/src/main/scala/besom/util/JsonInterpolator.scala
+++ b/core/src/main/scala/besom/util/JsonInterpolator.scala
@@ -1,0 +1,118 @@
+package besom.util
+
+import besom.json.*
+import besom.internal.{Context, Output}
+import scala.util.{Failure, Success}
+import besom.json.JsValue
+import interpolator.interleave
+import java.util.Objects
+
+object JsonInterpolator:
+  import scala.quoted.*
+
+  given {} with
+    extension (sc: StringContext)
+      inline def json(inline args: Any*)(using ctx: besom.internal.Context): Output[JsValue] = ${ jsonImpl('sc, 'args, 'ctx) }
+
+  private def jsonImpl(sc: Expr[StringContext], args: Expr[Seq[Any]], ctx: Expr[Context])(using Quotes): Expr[Output[JsValue]] =
+    import quotes.reflect.*
+
+    // this function traverses the tree of the given expression and tries to extract the constant string context tree from it in Right
+    // if it fails, it returns a Left with the final tree that couldn't be extracted from
+    def resolveStringContext(tree: Term, i: Int = 0): Either[Term, Seq[Expr[String]]] =
+      tree match
+        // resolve reference if possible
+        case t if t.tpe.termSymbol != Symbol.noSymbol && t.tpe <:< TypeRepr.of[StringContext] =>
+          t.tpe.termSymbol.tree match
+            case ValDef(_, _, Some(rhs)) => resolveStringContext(rhs, i + 1)
+            case _                       => Left(t)
+
+        // maybe resolved reference?
+        case other =>
+          tree.asExpr match
+            case '{ scala.StringContext.apply(${ Varargs(parts) }: _*) } =>
+              Right(parts)
+            case _ =>
+              Left(other)
+
+    resolveStringContext(sc.asTerm) match
+      case Left(badTerm) =>
+        report.errorAndAbort(s"$sc -> $badTerm is not a string context :O") // TODO what should we do here?
+
+      case Right(parts) =>
+        args match
+          case Varargs(argExprs) =>
+            if argExprs.isEmpty then
+              parts.map(_.valueOrAbort).mkString match
+                case "" => '{ Output(JsObject.empty)(using $ctx) }
+                case str =>
+                  scala.util.Try(JsonParser(str)) match
+                    case Failure(exception) =>
+                      report.errorAndAbort(s"Failed to parse JSON: ${exception.getMessage}")
+                    case Success(value) =>
+                      '{ Output(JsonParser(ParserInput.apply(${ Expr(str) })))(using $ctx) }
+            else
+              val defaults = argExprs.map {
+                case '{ $part: String }          => ""
+                case '{ $part: Int }             => 0
+                case '{ $part: Long }            => 0L
+                case '{ $part: Float }           => 0f
+                case '{ $part: Double }          => 0d
+                case '{ $part: Boolean }         => true
+                case '{ $part: JsValue }         => JsNull
+                case '{ $part: Output[String] }  => ""
+                case '{ $part: Output[Int] }     => 0
+                case '{ $part: Output[Long] }    => 0L
+                case '{ $part: Output[Float] }   => 0f
+                case '{ $part: Output[Double] }  => 0d
+                case '{ $part: Output[Boolean] } => true
+                case '{ $part: Output[JsValue] } => JsNull
+                case other => report.errorAndAbort(s"`${other.show}` / ${other} is not a valid interpolation type.") // TODO better error
+              }
+
+              val str = interleave(parts.map(_.valueOrAbort).toList, defaults.map(_.toString()).toList).reduce(_ + _)
+
+              scala.util.Try(JsonParser(str)) match
+                case Failure(exception) =>
+                  report.errorAndAbort(s"Failed to parse JSON (default values inserted at compile time): ${exception.getMessage}")
+                case Success(value) =>
+                  val liftedSeqOfExpr: Seq[Expr[Output[?]]] = argExprs.map {
+                    case '{ $part: String }          => '{ Output($part)(using $ctx) } // TODO sanitize strings
+                    case '{ $part: Int }             => '{ Output($part)(using $ctx) }
+                    case '{ $part: Long }            => '{ Output($part)(using $ctx) }
+                    case '{ $part: Float }           => '{ Output($part)(using $ctx) }
+                    case '{ $part: Double }          => '{ Output($part)(using $ctx) }
+                    case '{ $part: Boolean }         => '{ Output($part)(using $ctx) }
+                    case '{ $part: JsValue }         => '{ Output($part)(using $ctx) }
+                    case '{ $part: Output[String] }  => part // TODO sanitize strings
+                    case '{ $part: Output[Int] }     => part
+                    case '{ $part: Output[Long] }    => part
+                    case '{ $part: Output[Float] }   => part
+                    case '{ $part: Output[Double] }  => part
+                    case '{ $part: Output[Boolean] } => part
+                    case '{ $part: Output[JsValue] } => part
+                    case other => report.errorAndAbort(s"`${other.show}` is not a valid interpolation type.") // TODO better error
+                  }
+
+                  val liftedExprOfSeq = Expr.ofSeq(liftedSeqOfExpr)
+                  val liftedParts     = Expr.ofSeq(parts)
+
+                  '{
+                    interleave(${ liftedParts }.toList, ${ liftedExprOfSeq }.toList)
+                      .foldLeft(Output("")(using $ctx)) { case (acc, e) =>
+                        e match
+                          case o: Output[?] => acc.flatMap(s => o.map(v => s + Objects.toString(v))) // handle nulls too
+                          case s: String    => acc.map(_ + s)
+                      }
+                      .map { str =>
+                        scala.util.Try(JsonParser(str)) match
+                          case Failure(exception) =>
+                            throw Exception(s"Failed to parse JSON:\n$str", exception)
+                          case Success(value) =>
+                            value
+                      }
+                  }
+              end match
+    end match
+  end jsonImpl
+end JsonInterpolator

--- a/core/src/main/scala/besom/util/JsonInterpolator.scala
+++ b/core/src/main/scala/besom/util/JsonInterpolator.scala
@@ -39,7 +39,7 @@ object JsonInterpolator:
 
     resolveStringContext(sc.asTerm) match
       case Left(badTerm) =>
-        report.errorAndAbort(s"$sc -> $badTerm is not a string context :O") // TODO what should we do here?
+        report.errorAndAbort(s"$sc -> $badTerm is not a string context :O") // this should never happen
 
       case Right(parts) =>
         args match
@@ -50,7 +50,7 @@ object JsonInterpolator:
                 case str =>
                   scala.util.Try(JsonParser(str)) match
                     case Failure(exception) =>
-                      report.errorAndAbort(s"Failed to parse JSON: ${exception.getMessage}")
+                      report.errorAndAbort(s"Failed to parse JSON:$NL  ${exception.getMessage}")
                     case Success(value) =>
                       '{ Output(JsonParser(ParserInput.apply(${ Expr(str) })))(using $ctx) }
             else
@@ -82,7 +82,7 @@ object JsonInterpolator:
 
               scala.util.Try(JsonParser(str)) match
                 case Failure(exception) =>
-                  report.errorAndAbort(s"Failed to parse JSON (default values inserted at compile time): ${exception.getMessage}")
+                  report.errorAndAbort(s"Failed to parse JSON (default values inserted at compile time):$NL  ${exception.getMessage}")
                 case Success(value) =>
                   val liftedSeqOfExpr: Seq[Expr[Output[?]]] = argExprs.map {
                     case '{ $part: String } =>
@@ -92,7 +92,7 @@ object JsonInterpolator:
                           besom.json.CompactPrinter.print(JsString(str), sb) // escape strings
                           sb.toString().drop(1).dropRight(1) // json strings start and end with "
                         }
-                      } // TODO sanitize strings
+                      }
                     case '{ $part: Int }     => '{ Output($part)(using $ctx) }
                     case '{ $part: Long }    => '{ Output($part)(using $ctx) }
                     case '{ $part: Float }   => '{ Output($part)(using $ctx) }
@@ -106,7 +106,7 @@ object JsonInterpolator:
                           besom.json.CompactPrinter.print(JsString(str), sb) // escape strings
                           sb.toString().drop(1).dropRight(1) // json strings start and end with "
                         }
-                      } // TODO sanitize strings
+                      }
                     case '{ $part: Output[Int] }     => part
                     case '{ $part: Output[Long] }    => part
                     case '{ $part: Output[Float] }   => part

--- a/core/src/main/scala/besom/util/JsonInterpolator.scala
+++ b/core/src/main/scala/besom/util/JsonInterpolator.scala
@@ -12,9 +12,8 @@ object JsonInterpolator:
 
   private val NL = System.lineSeparator()
 
-  given {} with
-    extension (inline sc: StringContext)
-      inline def json(inline args: Any*)(using ctx: besom.internal.Context): Output[JsValue] = ${ jsonImpl('sc, 'args, 'ctx) }
+  extension (inline sc: StringContext)
+    inline def json(inline args: Any*)(using ctx: besom.internal.Context): Output[JsValue] = ${ jsonImpl('sc, 'args, 'ctx) }
 
   private def jsonImpl(sc: Expr[StringContext], args: Expr[Seq[Any]], ctx: Expr[Context])(using Quotes): Expr[Output[JsValue]] =
     import quotes.reflect.*

--- a/core/src/test/scala/besom/internal/ConfigTest.scala
+++ b/core/src/test/scala/besom/internal/ConfigTest.scala
@@ -3,7 +3,6 @@ package besom.internal
 import besom.*
 import besom.internal.RunResult.{*, given}
 import besom.json.*
-import besom.json.DefaultJsonProtocol.*
 
 class ConfigTest extends munit.FunSuite {
 

--- a/core/src/test/scala/besom/internal/ConfigTest.scala
+++ b/core/src/test/scala/besom/internal/ConfigTest.scala
@@ -202,9 +202,7 @@ class ConfigTest extends munit.FunSuite {
     assertEquals(actual, expected)
   }
 
-  case class Foo(a: Int, b: Int)
-  object Foo:
-    given JsonFormat[Foo] = jsonFormatN
+  case class Foo(a: Int, b: Int) derives JsonFormat
   testConfig("get case class Foo")(
     configMap = Map("foo" -> """{"a":1,"b":2}"""),
     configSecretKeys = Set("foo"),

--- a/core/src/test/scala/besom/util/CompileAssertions.scala
+++ b/core/src/test/scala/besom/util/CompileAssertions.scala
@@ -3,6 +3,11 @@ package besom.util
 trait CompileAssertions:
   self: munit.FunSuite =>
 
+  import scala.language.dynamics
+
+  object code extends Dynamic:
+    transparent inline def selectDynamic(name: String): name.type = name
+
   private val NL = System.lineSeparator()
 
   inline def failsToCompile(inline code: String): Unit =

--- a/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
+++ b/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
@@ -1,0 +1,134 @@
+package besom.util
+
+import munit.*
+import besom.json.JsonParser
+
+class JsonInterpolatorTest extends FunSuite with CompileAssertions:
+
+  test("json interpolator should compile with correct json strings") {
+    // baseline
+    compiles(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.DummyContext
+         import besom.internal.RunResult.*
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+      """ +
+        code.`val x = json"""{"a": 1, "b": 2}"""`
+    )
+
+    compiles(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.DummyContext
+         import besom.internal.RunResult.*
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         val i = 2
+      """ +
+        code.`val x = json"""{"a": 1, "b": $i}"""`
+    )
+  }
+
+  test("json interpolator should catch invalid jsons") {
+    failsToCompile(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.DummyContext
+         import besom.internal.RunResult.*
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+      """ +
+        code.`val x = json"""{"a": 1, "b": 2"""`
+    )
+
+    failsToCompile(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.DummyContext
+         import besom.internal.RunResult.*
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+      """ +
+        code.`val x = json"""{"a": 1, "b": 2,}"""`
+    )
+
+    failsToCompile(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.DummyContext
+         import besom.internal.RunResult.*
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+      """ +
+        code.`val x = json"""{"a"": 1, "b": 2}"""`
+    )
+  }
+
+  test("json interpolator should interpolate primitives into json strings correctly") {
+    import besom.util.JsonInterpolator.given
+    import besom.internal.DummyContext
+    import besom.internal.RunResult.given
+    import besom.internal.RunOutput.{*, given}
+    import besom.internal.Output
+
+    given besom.internal.Context = DummyContext().unsafeRunSync()
+
+    val str        = "test"
+    val int        = 1
+    val long       = 5L
+    val float      = Output(2.3f)
+    val double     = 3.4d
+    val bool       = true
+    val jsonOutput = json"""{"a": 1, "b": "$str", "c": $int, "d": $long, "e": $float, "f": $double, "g": $bool}"""
+    jsonOutput.unsafeRunSync() match
+      case None => fail("expected a json output")
+      case Some(json) =>
+        assertEquals(json, JsonParser("""{"a": 1, "b": "test", "c": 1, "d": 5, "e": 2.3, "f": 3.4, "g": true}"""))
+  }
+
+  test("json interpolator should interpolate JsValues into json strings correctly") {
+    import besom.json.*
+    import besom.util.JsonInterpolator.given
+    import besom.internal.DummyContext
+    import besom.internal.RunResult.given
+    import besom.internal.RunOutput.{*, given}
+
+    given besom.internal.Context = DummyContext().unsafeRunSync()
+
+    val jsonValue  = JsObject("a" -> JsNumber(1), "b" -> JsString("test"))
+    val jsonOutput = json"""{"a": 1, "b": $jsonValue}"""
+    jsonOutput.unsafeRunSync() match
+      case None => fail("expected a json output")
+      case Some(json) =>
+        assertEquals(json, JsonParser("""{"a": 1, "b": {"a": 1, "b": "test"}}"""))
+  }
+
+  test("json interpolator fails to compile when interpolating values that can't be interpolated") {
+    failsToCompile(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.DummyContext
+         import besom.internal.RunResult.*
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+      """ +
+        code.`val x = json"""{"a": 1, "b": $this}"""`
+    )
+
+    failsToCompile(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.DummyContext
+         import besom.internal.RunResult.*
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+      """ +
+        code.`val x = json"""{"a": 1, "b": $this}"""`
+    )
+  }
+
+  test("json interpolator sanitizes strings when interpolating".ignore) {
+    import besom.json.*
+    import besom.util.JsonInterpolator.given
+    import besom.internal.DummyContext
+    import besom.internal.RunResult.given
+    import besom.internal.RunOutput.{*, given}
+
+    given besom.internal.Context = DummyContext().unsafeRunSync()
+
+    val badString = """well well well", "this is onixpected": "23"""
+    json"""{"a": 1, "b": "$badString"}""".unsafeRunSync() match
+      case None => fail("expected a json output")
+      case Some(json) =>
+        assertEquals(json, JsonParser("""{"a": 1, "b": "well well well\", \"this is onixpected\": \"23"}"""))
+  }
+
+end JsonInterpolatorTest

--- a/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
+++ b/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
@@ -2,6 +2,9 @@ package besom.util
 
 import munit.*
 import besom.json.JsonParser
+import scala.annotation.unused
+
+class Outer[A](@unused a: A)
 
 class JsonInterpolatorTest extends FunSuite with CompileAssertions:
 
@@ -65,17 +68,17 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
 
     given besom.internal.Context = DummyContext().unsafeRunSync()
 
-    val str        = "test"
+    val str        = "\"test"
     val int        = 1
     val long       = 5L
     val float      = Output(2.3f)
     val double     = 3.4d
     val bool       = true
-    val jsonOutput = json"""{"a": 1, "b": "$str", "c": $int, "d": $long, "e": $float, "f": $double, "g": $bool}"""
+    val jsonOutput = json"""{"a": 1, "b": $str, "c": $int, "d": $long, "e": $float, "f": $double, "g": $bool}"""
     jsonOutput.unsafeRunSync() match
       case None => fail("expected a json output")
       case Some(json) =>
-        assertEquals(json, JsonParser("""{"a": 1, "b": "test", "c": 1, "d": 5, "e": 2.3, "f": 3.4, "g": true}"""))
+        assertEquals(json, JsonParser("""{"a": 1, "b": "\"test", "c": 1, "d": 5, "e": 2.3, "f": 3.4, "g": true}"""))
   }
 
   test("json interpolator should interpolate JsValues into json strings correctly") {
@@ -95,7 +98,39 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
         assertEquals(json, JsonParser("""{"a": 1, "b": {"a": 1, "b": "test"}}"""))
   }
 
-  test("json interpolator fails to compile when interpolating values that can't be interpolated") {
+  test("json interpolator can interpolate wrapped values correctly") {
+    import besom.json.*
+    import besom.util.JsonInterpolator.given
+    import besom.internal.DummyContext
+    import besom.internal.RunResult.given
+    import besom.internal.RunOutput.{*, given}
+    import besom.internal.Output
+
+    given besom.internal.Context = DummyContext().unsafeRunSync()
+
+    val str         = Option(Some("test"))
+    val int         = Output(Option(1))
+    val long        = Some(Output(5L))
+    val float       = Output(Some(2.3f))
+    val double      = Option(Output(3.4d))
+    val bool        = Output(Output(true))
+    val nullValue   = None
+    val anotherNull = Some(None)
+    val literalNull = null: String
+
+    val jsonOutput =
+      json"""{"a": 1, "b": $str, "c": $int, "d": $long, "e": $float, "f": $double, "g": $bool, "h": $nullValue, "i": $anotherNull, "j": $literalNull}"""
+
+    jsonOutput.unsafeRunSync() match
+      case None => fail("expected a json output")
+      case Some(json) =>
+        assertEquals(
+          json,
+          JsonParser("""{"a": 1, "b": "test", "c": 1, "d": 5, "e": 2.3, "f": 3.4, "g": true, "h": null, "i": null, "j": null}""")
+        )
+  }
+
+  test("json interpolator fails to compile when interpolating values that can't be interpolated with nice error messages") {
     failsToCompile(
       """import besom.util.JsonInterpolator.given
          import besom.internal.DummyContext
@@ -113,6 +148,153 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
       """ +
         code.`val x = json"""{"a": 1, "b": $this}"""`
     )
+
+    val errsWrappedOutput = scala.compiletime.testing.typeCheckErrors(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.{Output, DummyContext}
+         import besom.internal.RunOutput.{*, given}
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         
+         def x = Output(java.time.Instant.now())
+      """ +
+        code.`val json = json"""{"a": 1, "b": $x}"""`
+    )
+
+    val expectedErrorWrappedOutput =
+      """Value of type `besom.internal.Output[java.time.Instant]` is not a valid JSON interpolation type because of type `java.time.Instant`.
+        |
+        |Types available for interpolation are: String, Int, Short, Long, Float, Double, Boolean, JsValue and Options and Outputs containing these types.
+        |If you want to interpolate a custom data type - derive or implement a JsonFormat for it and convert it to JsValue.
+        |""".stripMargin
+
+    assert(errsWrappedOutput.size == 1, s"expected 1 errors, got ${errsWrappedOutput.size}")
+    assertEquals(errsWrappedOutput.head.message, expectedErrorWrappedOutput)
+
+    val errsWrappedOption = scala.compiletime.testing.typeCheckErrors(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.{Output, DummyContext}
+         import besom.internal.RunOutput.{*, given}
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         
+         val x = Option(java.time.Instant.now())
+      """ +
+        code.`val json = json"""{"a": 1, "b": $x}"""`
+    )
+
+    val expectedErrorWrappedOption =
+      """Value of type `scala.Option[java.time.Instant]` is not a valid JSON interpolation type because of type `java.time.Instant`.
+        |
+        |Types available for interpolation are: String, Int, Short, Long, Float, Double, Boolean, JsValue and Options and Outputs containing these types.
+        |If you want to interpolate a custom data type - derive or implement a JsonFormat for it and convert it to JsValue.
+        |""".stripMargin
+
+    assert(errsWrappedOption.size == 1, s"expected 1 errors, got ${errsWrappedOption.size}")
+    assertEquals(errsWrappedOption.head.message, expectedErrorWrappedOption)
+
+    val errsWrappedOutputOption = scala.compiletime.testing.typeCheckErrors(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.{Output, DummyContext}
+         import besom.internal.RunOutput.{*, given}
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         
+         val x = Output(Option(java.time.Instant.now()))
+      """ +
+        code.`val json = json"""{"a": 1, "b": $x}"""`
+    )
+
+    val expectedErrorWrappedOutputOption =
+      """Value of type `besom.internal.Output[scala.Option[java.time.Instant]]` is not a valid JSON interpolation type because of type `java.time.Instant`.
+        |
+        |Types available for interpolation are: String, Int, Short, Long, Float, Double, Boolean, JsValue and Options and Outputs containing these types.
+        |If you want to interpolate a custom data type - derive or implement a JsonFormat for it and convert it to JsValue.
+        |""".stripMargin
+
+    assert(errsWrappedOutputOption.size == 1, s"expected 1 errors, got ${errsWrappedOutputOption.size}")
+    assertEquals(errsWrappedOutputOption.head.message, expectedErrorWrappedOutputOption)
+
+    val errsWrappedOptionOutput = scala.compiletime.testing.typeCheckErrors(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.{Output, DummyContext}
+         import besom.internal.RunOutput.{*, given}
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         
+         val x = Option(Output(java.time.Instant.now()))
+      """ +
+        code.`val json = json"""{"a": 1, "b": $x}"""`
+    )
+
+    val expectedErrorWrappedOptionOutput =
+      """Value of type `scala.Option[besom.internal.Output[java.time.Instant]]` is not a valid JSON interpolation type because of type `java.time.Instant`.
+        |
+        |Types available for interpolation are: String, Int, Short, Long, Float, Double, Boolean, JsValue and Options and Outputs containing these types.
+        |If you want to interpolate a custom data type - derive or implement a JsonFormat for it and convert it to JsValue.
+        |""".stripMargin
+
+    assert(errsWrappedOptionOutput.size == 1, s"expected 1 errors, got ${errsWrappedOptionOutput.size}")
+    assertEquals(errsWrappedOptionOutput.head.message, expectedErrorWrappedOptionOutput)
+
+    val errsWrappedOutputOutput = scala.compiletime.testing.typeCheckErrors(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.{Output, DummyContext}
+         import besom.internal.RunOutput.{*, given}
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         
+         val x = Output(Output(java.time.Instant.now()))
+      """ +
+        code.`val json = json"""{"a": 1, "b": $x}"""`
+    )
+
+    val expectedErrorWrappedOutputOutput =
+      """Value of type `besom.internal.Output[besom.internal.Output[java.time.Instant]]` is not a valid JSON interpolation type because of type `java.time.Instant`.
+        |
+        |Types available for interpolation are: String, Int, Short, Long, Float, Double, Boolean, JsValue and Options and Outputs containing these types.
+        |If you want to interpolate a custom data type - derive or implement a JsonFormat for it and convert it to JsValue.
+        |""".stripMargin
+
+    assert(errsWrappedOutputOutput.size == 1, s"expected 1 errors, got ${errsWrappedOutputOutput.size}")
+    assertEquals(errsWrappedOutputOutput.head.message, expectedErrorWrappedOutputOutput)
+
+    val errsWrappedOptionOption = scala.compiletime.testing.typeCheckErrors(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.{Output, DummyContext}
+         import besom.internal.RunOutput.{*, given}
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         
+         val x = Option(Option(java.time.Instant.now()))
+      """ +
+        code.`val json = json"""{"a": 1, "b": $x}"""`
+    )
+
+    val expectedErrorWrappedOptionOption =
+      """Value of type `scala.Option[scala.Option[java.time.Instant]]` is not a valid JSON interpolation type because of type `java.time.Instant`.
+        |
+        |Types available for interpolation are: String, Int, Short, Long, Float, Double, Boolean, JsValue and Options and Outputs containing these types.
+        |If you want to interpolate a custom data type - derive or implement a JsonFormat for it and convert it to JsValue.
+        |""".stripMargin
+
+    assert(errsWrappedOptionOption.size == 1, s"expected 1 errors, got ${errsWrappedOptionOption.size}")
+    assertEquals(errsWrappedOptionOption.head.message, expectedErrorWrappedOptionOption)
+
+    val errsWrappedOuter = scala.compiletime.testing.typeCheckErrors(
+      """import besom.util.JsonInterpolator.given
+         import besom.internal.{Output, DummyContext}
+         import besom.internal.RunOutput.{*, given}
+         given besom.internal.Context = DummyContext().unsafeRunSync()
+         
+         val x = new Outer(1)
+      """ +
+        code.`val json = json"""{"a": 1, "b": $x}"""`
+    )
+
+    val expectedErrorWrappedOuter =
+      """Value of type `x: besom.util.Outer` is not a valid JSON interpolation type.
+        |
+        |Types available for interpolation are: String, Int, Short, Long, Float, Double, Boolean, JsValue and Options and Outputs containing these types.
+        |If you want to interpolate a custom data type - derive or implement a JsonFormat for it and convert it to JsValue.
+        |""".stripMargin
+
+    assert(errsWrappedOuter.size == 1, s"expected 1 errors, got ${errsWrappedOuter.size}")
+    assertEquals(errsWrappedOuter.head.message, expectedErrorWrappedOuter)
   }
 
   test("json interpolator sanitizes strings when interpolating") {
@@ -125,7 +307,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     given besom.internal.Context = DummyContext().unsafeRunSync()
 
     val badString = """well well well", "this is onixpected": "23"""
-    json"""{"a": 1, "b": "$badString"}""".unsafeRunSync() match
+    json"""{"a": 1, "b": $badString}""".unsafeRunSync() match
       case None => fail("expected a json output")
       case Some(json) =>
         assertEquals(json, JsonParser("""{"a": 1, "b": "well well well\", \"this is onixpected\": \"23"}"""))

--- a/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
+++ b/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
@@ -1,7 +1,6 @@
 package besom.util
 
 import munit.*
-import besom.json.JsonParser
 import scala.annotation.unused
 
 class Outer[A](@unused a: A)
@@ -11,7 +10,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
   test("json interpolator should compile with correct json strings") {
     // baseline
     compiles(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.DummyContext
          import besom.internal.RunResult.*
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -20,7 +19,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     )
 
     compiles(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.DummyContext
          import besom.internal.RunResult.*
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -32,7 +31,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
 
   test("json interpolator should catch invalid jsons") {
     failsToCompile(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.DummyContext
          import besom.internal.RunResult.*
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -41,7 +40,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     )
 
     failsToCompile(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.DummyContext
          import besom.internal.RunResult.*
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -50,7 +49,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     )
 
     failsToCompile(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.DummyContext
          import besom.internal.RunResult.*
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -60,7 +59,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
   }
 
   test("json interpolator should interpolate primitives into json strings correctly") {
-    import besom.util.JsonInterpolator.given
+    import besom.json.*
     import besom.internal.DummyContext
     import besom.internal.RunResult.given
     import besom.internal.RunOutput.{*, given}
@@ -83,7 +82,6 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
 
   test("json interpolator should interpolate JsValues into json strings correctly") {
     import besom.json.*
-    import besom.util.JsonInterpolator.given
     import besom.internal.DummyContext
     import besom.internal.RunResult.given
     import besom.internal.RunOutput.{*, given}
@@ -100,7 +98,6 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
 
   test("json interpolator can interpolate wrapped values correctly") {
     import besom.json.*
-    import besom.util.JsonInterpolator.given
     import besom.internal.DummyContext
     import besom.internal.RunResult.given
     import besom.internal.RunOutput.{*, given}
@@ -132,7 +129,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
 
   test("json interpolator fails to compile when interpolating values that can't be interpolated with nice error messages") {
     failsToCompile(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.DummyContext
          import besom.internal.RunResult.*
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -141,7 +138,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     )
 
     failsToCompile(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.DummyContext
          import besom.internal.RunResult.*
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -150,7 +147,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     )
 
     val errsWrappedOutput = scala.compiletime.testing.typeCheckErrors(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.{Output, DummyContext}
          import besom.internal.RunOutput.{*, given}
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -171,7 +168,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     assertEquals(errsWrappedOutput.head.message, expectedErrorWrappedOutput)
 
     val errsWrappedOption = scala.compiletime.testing.typeCheckErrors(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.{Output, DummyContext}
          import besom.internal.RunOutput.{*, given}
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -192,7 +189,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     assertEquals(errsWrappedOption.head.message, expectedErrorWrappedOption)
 
     val errsWrappedOutputOption = scala.compiletime.testing.typeCheckErrors(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.{Output, DummyContext}
          import besom.internal.RunOutput.{*, given}
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -213,7 +210,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     assertEquals(errsWrappedOutputOption.head.message, expectedErrorWrappedOutputOption)
 
     val errsWrappedOptionOutput = scala.compiletime.testing.typeCheckErrors(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.{Output, DummyContext}
          import besom.internal.RunOutput.{*, given}
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -234,7 +231,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     assertEquals(errsWrappedOptionOutput.head.message, expectedErrorWrappedOptionOutput)
 
     val errsWrappedOutputOutput = scala.compiletime.testing.typeCheckErrors(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.{Output, DummyContext}
          import besom.internal.RunOutput.{*, given}
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -255,7 +252,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     assertEquals(errsWrappedOutputOutput.head.message, expectedErrorWrappedOutputOutput)
 
     val errsWrappedOptionOption = scala.compiletime.testing.typeCheckErrors(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.{Output, DummyContext}
          import besom.internal.RunOutput.{*, given}
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -276,7 +273,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     assertEquals(errsWrappedOptionOption.head.message, expectedErrorWrappedOptionOption)
 
     val errsWrappedOuter = scala.compiletime.testing.typeCheckErrors(
-      """import besom.util.JsonInterpolator.given
+      """import besom.json.*
          import besom.internal.{Output, DummyContext}
          import besom.internal.RunOutput.{*, given}
          given besom.internal.Context = DummyContext().unsafeRunSync()
@@ -299,7 +296,6 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
 
   test("json interpolator sanitizes strings when interpolating") {
     import besom.json.*
-    import besom.util.JsonInterpolator.given
     import besom.internal.DummyContext
     import besom.internal.RunResult.given
     import besom.internal.RunOutput.{*, given}

--- a/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
+++ b/core/src/test/scala/besom/util/JsonInterpolatorTest.scala
@@ -115,7 +115,7 @@ class JsonInterpolatorTest extends FunSuite with CompileAssertions:
     )
   }
 
-  test("json interpolator sanitizes strings when interpolating".ignore) {
+  test("json interpolator sanitizes strings when interpolating") {
     import besom.json.*
     import besom.util.JsonInterpolator.given
     import besom.internal.DummyContext

--- a/integration-tests/resources/config-example/Main.scala
+++ b/integration-tests/resources/config-example/Main.scala
@@ -14,9 +14,7 @@ import besom.*
   import besom.json.*, DefaultJsonProtocol.*
   val names = config.requireObject[List[String]]("names")
 
-  case class Foo(name: String, age: Int) derives Encoder
-  object Foo:
-    given JsonFormat[Foo] = jsonFormatN
+  case class Foo(name: String, age: Int) derives Encoder, JsonFormat
 
   val foo = config.requireObject[Foo]("foo")
 

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -45,7 +45,7 @@ s3.BucketPolicyArgs(
   }""".map(_.prettyPrint)
 )
 ```
-The json interpolator returns an `Output[JsValue]` and is fully compile-time type safe and verifies JSON string for correctness. 
+The json interpolator returns an `Output[JsValue]` and is fully **compile-time type safe** and verifies JSON string for correctness. 
 The only types that can be interpolated are `String`, `Int`, `Short`, `Long`, `Float`, `Double`, `JsValue` and `Option` and `Output` 
 of the former (in whatever amount of nesting). If you need to interpolate a more complex type it's advised to derive a `JsonFormat` 
 for it and convert it to `JsValue`.

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -7,7 +7,7 @@ title: Changelog
 
 ## API Changes and New Features
 
-* Added new besom.json interpolation API. Now this snippet from our tutorial:
+* Added new `besom.json` interpolation API. Now this snippet from our tutorial:
 ```scala
 s3.BucketPolicyArgs(
   bucket = feedBucket.id,

--- a/website/docs/changelog.md
+++ b/website/docs/changelog.md
@@ -50,7 +50,7 @@ The only types that can be interpolated are `String`, `Int`, `Short`, `Long`, `F
 of the former (in whatever amount of nesting). If you need to interpolate a more complex type it's advised to derive a `JsonFormat` 
 for it and convert it to `JsValue`.
 
-* Package besom.json was modified to ease the use of `JsonFormat` derivation. This change is breaking compatibility by exporting 
+* Package `besom.json` was modified to ease the use of `JsonFormat` derivation. This change is breaking compatibility by exporting 
 default instances from `DefaultJsonProtocol` and providing a given `JsonProtocol` instance for use with `derives JsonFormat`.
 If you need to define a custom `JsonProcol` change the import to `import besom.json.custom.*` which preserves the older semantics
 from spray-json and requires manual extension of `DefaultJsonProtocol`.

--- a/website/docs/json.md
+++ b/website/docs/json.md
@@ -69,7 +69,7 @@ s3.BucketPolicyArgs(
 )
 ```
 
-For ease of use with Besom Inputs in provider packages interpolator returns an `Output[JsValue]`.
+For ease of use with Besom `Input`s in provider packages interpolator returns an `Output[JsValue]`.
 
 The JSON interpolator is available when using `import besom.json.*` or `import besom.util.JsonInterpolator.*` imports. Interpolator is 
 completely **compile-time type safe** and verifies JSON string for correctness by substituting. The only types that can be interpolated are 

--- a/website/docs/json.md
+++ b/website/docs/json.md
@@ -72,6 +72,6 @@ s3.BucketPolicyArgs(
 For ease of use with Besom Inputs in provider packages interpolator returns an `Output[JsValue]`.
 
 The JSON interpolator is available when using `import besom.json.*` or `import besom.util.JsonInterpolator.*` imports. Interpolator is 
-completely compile-time type safe and verifies JSON string for correctness by substituting . The only types that can be interpolated are 
+completely **compile-time type safe** and verifies JSON string for correctness by substituting. The only types that can be interpolated are 
 `String`, `Int`, `Short`, `Long`, `Float`, `Double`, `JsValue` and `Option` and `Output` of the former (in whatever amount of nesting). 
 If you need to interpolate a more complex type it's advised to derive a `JsonFormat` for it and convert it to `JsValue`.

--- a/website/docs/json.md
+++ b/website/docs/json.md
@@ -69,7 +69,7 @@ s3.BucketPolicyArgs(
 
 For ease of use with Besom Inputs in provider packages interpolator returns an `Output[JsValue]`.
 
-The JSON interpolator is available when using both `import besom.json.*` and `import besom.json.custom.*` imports. Interpolator is completely 
-compile-time type safe and verifies JSON string for correctness by substituting . The only types that can be interpolated are `String`, `Int`, `Short`, `Long`, 
-`Float`, `Double`, `JsValue` and `Option` and `Output` of the former (in whatever amount of nesting). If you need to interpolate a more complex 
-type it's advised to derive a `JsonFormat` for it and convert it to `JsValue`.
+The JSON interpolator is available when using `import besom.json.*` or `import besom.util.JsonInterpolator.*` imports. Interpolator is 
+completely compile-time type safe and verifies JSON string for correctness by substituting . The only types that can be interpolated are 
+`String`, `Int`, `Short`, `Long`, `Float`, `Double`, `JsValue` and `Option` and `Output` of the former (in whatever amount of nesting). 
+If you need to interpolate a more complex type it's advised to derive a `JsonFormat` for it and convert it to `JsValue`.

--- a/website/docs/json.md
+++ b/website/docs/json.md
@@ -26,7 +26,7 @@ assert(json.parseJson.convertTo[Color] == color)
 
 #### JSON Interpolator
 
-Besom-json package has also a convenient json interpolator that allows one to rewrite snippets like this
+The `besom-json` package has also a convenient JSON interpolator that allows one to rewrite snippets like this
 where cloud provider API expects a JSON string:
 
 ```scala

--- a/website/docs/json.md
+++ b/website/docs/json.md
@@ -3,7 +3,9 @@ title: JSON API
 ---
 
 Besom comes with it's own JSON library to avoid any issues with classpath clashes with mainstream JSON libraries when embedding
-Besom infrastructural programs in Scala applications via AutomationAPI. Package `besom.json` is a fork of well-known, battle-tested 
+Besom infrastructural programs in Scala applications via AutomationAPI. 
+
+Package `besom.json` is a fork of well-known, battle-tested 
 [spray-json](https://github.com/spray/spray-json) library. Specifically, the `spray-json` has been ported to Scala 3 with some 
 breaking changes and received support for `derives` keyword. Another change is that import of `besom.json.*` brings all the 
 `JsonFormat` instances from `DefaultJsonProtocol` into scope and to get the old experience to how `spray-json` operated one needs 

--- a/website/docs/json.md
+++ b/website/docs/json.md
@@ -27,7 +27,7 @@ assert(json.parseJson.convertTo[Color] == color)
 #### JSON Interpolator
 
 The `besom-json` package has also a convenient JSON interpolator that allows one to rewrite snippets like this
-where cloud provider API expects a JSON string:
+where a cloud provider API expects a JSON string:
 
 ```scala
 s3.BucketPolicyArgs(

--- a/website/docs/json.md
+++ b/website/docs/json.md
@@ -1,0 +1,75 @@
+---
+title: JSON API
+---
+
+Besom comes with it's own JSON library to avoid any issues with classpath clashes with mainstream JSON libraries when embedding
+Besom infrastructural programs in Scala applications via AutomationAPI. Package `besom.json` is a fork of well-known, battle-tested 
+[spray-json](https://github.com/spray/spray-json) library. Specifically, the `spray-json` has been ported to Scala 3 with some 
+breaking changes and received support for `derives` keyword. Another change is that import of `besom.json.*` brings all the 
+`JsonFormat` instances from `DefaultJsonProtocol` into scope and to get the old experience to how `spray-json` operated one needs 
+to import `besom.json.custom.*`. 
+
+A sample use of the package:
+```scala
+import besom.json.*
+
+case class Color(name: String, red: Int, green: Int, blue: Int = 160) derives JsonFormat
+val color = Color("CadetBlue", 95, 158)
+
+val json = """{"name":"CadetBlue","red":95,"green":158}"""
+
+assert(color.toJson.convertTo[Color] == color)
+assert(json.parseJson.convertTo[Color] == color)
+```
+
+#### JSON Interpolator
+
+Besom-json package has also a convenient json interpolator that allows one to rewrite snippets like this
+where cloud provider API expects a JSON string:
+
+```scala
+s3.BucketPolicyArgs(
+  bucket = feedBucket.id,
+  policy = JsObject(
+    "Version" -> JsString("2012-10-17"),
+    "Statement" -> JsArray(
+      JsObject(
+        "Sid" -> JsString("PublicReadGetObject"),
+        "Effect" -> JsString("Allow"),
+        "Principal" -> JsObject(
+          "AWS" -> JsString("*")
+        ),
+        "Action" -> JsArray(JsString("s3:GetObject")),
+        "Resource" -> JsArray(JsString(s"arn:aws:s3:::${name}/*"))
+      )
+    )
+  ).prettyPrint
+)
+```
+
+into simpler and less clunky interpolated variant like this: 
+
+```scala
+s3.BucketPolicyArgs(
+  bucket = feedBucket.id,
+  policy = json"""{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:aws:s3::${name}/*"]
+    }]
+  }""".map(_.prettyPrint)
+)
+```
+
+For ease of use with Besom Inputs in provider packages interpolator returns an `Output[JsValue]`.
+
+The JSON interpolator is available when using both `import besom.json.*` and `import besom.json.custom.*` imports. Interpolator is completely 
+compile-time type safe and verifies JSON string for correctness by substituting . The only types that can be interpolated are `String`, `Int`, `Short`, `Long`, 
+`Float`, `Double`, `JsValue` and `Option` and `Output` of the former (in whatever amount of nesting). If you need to interpolate a more complex 
+type it's advised to derive a `JsonFormat` for it and convert it to `JsValue`.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -51,6 +51,8 @@ const config = {
     besomVersion: besomVersion
   },
 
+  trailingSlash: true,
+
   presets: [
     [
       'classic',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -50,6 +50,7 @@ const sidebars = {
         'lifting',
         'interpolator',
         'components',
+        'json',
         'compiler_plugin',
         'missing'
       ],


### PR DESCRIPTION
* Adds `import besom.json.default.*` to allow easy use of derivation without `given JsonProtocol = DefaultJsonProtocol`
* Adds `json""` interpolator that verifies json correctness in compile time and interpolates Outputs like `pulumi""` interpolator
* besom.json handles default args correctly now (if a field is missing in json and constructor has a default argument for that field, default value will be used) 

Still needs: changes in examples and a JSON section in docs.

BREAKS BINCOMPAT ON besom.json !!! Release as next minor.