### PR TITLE
Add alias and docs for custom timeouts

### DIFF
--- a/core/src/main/scala/besom/aliases.scala
+++ b/core/src/main/scala/besom/aliases.scala
@@ -48,6 +48,7 @@ object aliases:
     object StackRef extends besom.internal.ResourceOptsVariant.StackRef
     object Custom extends besom.internal.ResourceOptsVariant.Custom
     object Component extends besom.internal.ResourceOptsVariant.Component
+  type CustomTimeouts = besom.internal.CustomTimeouts
 
   export besom.internal.InvokeOptions
 end aliases

--- a/core/src/main/scala/besom/internal/CustomTimeouts.scala
+++ b/core/src/main/scala/besom/internal/CustomTimeouts.scala
@@ -3,13 +3,35 @@ package besom.internal
 import scala.concurrent.duration.Duration
 import besom.util.*
 
+/** Custom timeouts for create, update and delete operations.
+  *
+  * @param create
+  *   The optional create timeout represented as a string e.g. `5.minutes`, `40.seconds`, `1.day`
+  * @param update
+  *   The optional update timeout represented as a string e.g. `5.minutes`, `40.seconds`, `1.day`
+  * @param delete
+  *   The optional delete timeout represented as a string e.g. `5.minutes`, `40.seconds`, `1.day`
+  * @return
+  *   A new instance of [[CustomTimeouts]]
+  *
+  * @see
+  *   [[BesomSyntax.opts]]
+  * @see
+  *   [[besom.ComponentResourceOptions]]
+  * @see
+  *   [[besom.CustomResourceOptions]]
+  * @see
+  *   [[besom.StackReferenceResourceOptions]]
+  */
 case class CustomTimeouts(create: Option[Duration], update: Option[Duration], delete: Option[Duration])
 
+/** Companion object for [[CustomTimeouts]] */
 object CustomTimeouts:
   def apply(
     create: Duration | NotProvided = NotProvided,
     update: Duration | NotProvided = NotProvided,
     delete: Duration | NotProvided = NotProvided
-  ): CustomTimeouts = CustomTimeouts(create.asOption, update.asOption, delete.asOption)
+  ): CustomTimeouts = new CustomTimeouts(create.asOption, update.asOption, delete.asOption)
 
+  // noinspection ScalaUnusedSymbol
   private[besom] def toGoDurationString(duration: Duration): String = s"${duration.toNanos}ns"


### PR DESCRIPTION
I've noticed we lack non-internal alias for CustomTimeout we've added recently, this change adds and along with basic scaladoc.