### PR TITLE
Fix AggregateException

### DIFF
--- a/codegen/src/CodegenError.scala
+++ b/codegen/src/CodegenError.scala
@@ -51,7 +51,7 @@ object AggregateCodegenError {
     def message(t: Throwable) = s"[${t.getClass.getSimpleName}] '${Option(t.getMessage).getOrElse("no message")}'"
     val msg                   = s"""Multiple Errors: ${errors.map(message).mkString(", ")}"""
     val cause = errors.headOption.map { head =>
-      errors.foreach(head.addSuppressed)
+      errors.tail.foreach(head.addSuppressed)
       head
     }
     new AggregateCodegenError(Some(msg), cause, errors)

--- a/core/src/main/scala/besom/util/Validated.scala
+++ b/core/src/main/scala/besom/util/Validated.scala
@@ -165,6 +165,12 @@ final case class NonEmptyVector[+A](head: A, tail: Vector[A]):
   def toVector: Vector[A] = head +: tail
   def map[B](f: A => B): NonEmptyVector[B] =
     NonEmptyVector(f(head), tail.map(f))
+  def foreach(f: A => Unit): Unit =
+    f(head)
+    tail.foreach(f)
+  def size: Int = 1 + tail.size
+  def mkString(start: String, sep: String, end: String): String =
+    toVector.mkString(start, sep, end)
 
 object NonEmptyVector:
   def apply[A](head: A, tail: A*): NonEmptyVector[A] = NonEmptyVector(head, tail.toVector)


### PR DESCRIPTION
- preserve cause and all other causes

Example:

```scala
val errors = NonEmptyVector(
      DecodingError("error1", label = Label.fromNameAndType("dummy1", "dummy:pkg:Dummy1"), cause = Exception("cause1")),
      DecodingError("error2", label = Label.fromNameAndType("dummy2", "dummy:pkg:Dummy1")),
      DecodingError("error3", label = Label.fromNameAndType("dummy3", "dummy:pkg:Dummy1"))
    )
    val aggregated = AggregatedDecodingError(errors)
```
```
besom.internal.AggregatedDecodingError: Decoding Errors [3]:
  error1
  error2
  error3
(with aggregate stack trace)
	at besom.internal.AggregatedDecodingError$.apply(codecs.scala:100)
	at besom.internal.InternalTest.$init$$$anonfun$34(EncoderTest.scala:996)
	at munit.internal.console.StackTraces$.dropOutside(StackTraces.scala:12)
	...
	at munit.internal.junitinterface.JUnitTask.execute(JUnitTask.java:87)
	at scala.build.testrunner.TestRunner$.runTasks(TestRunner.scala:70)
	at scala.build.testrunner.DynamicTestRunner$.main(DynamicTestRunner.scala:260)
	at scala.build.testrunner.DynamicTestRunner.main(DynamicTestRunner.scala)
Caused by: besom.internal.DecodingError: [dummy1[dummy:pkg:Dummy1]] error1
	at besom.internal.DecodingError$.apply(codecs.scala:80)
	at besom.internal.InternalTest.$init$$$anonfun$34(EncoderTest.scala:992)
	... 53 more
	Suppressed: besom.internal.DecodingError: [dummy2[dummy:pkg:Dummy1]] error2
		at besom.internal.DecodingError$.apply(codecs.scala:81)
		at besom.internal.InternalTest.$init$$$anonfun$34(EncoderTest.scala:993)
		... 53 more
	Suppressed: besom.internal.DecodingError: [dummy3[dummy:pkg:Dummy1]] error3
		at besom.internal.DecodingError$.apply(codecs.scala:81)
		at besom.internal.InternalTest.$init$$$anonfun$34(EncoderTest.scala:994)
		... 53 more
Caused by: java.lang.Exception: cause1
	... 54 more
```