### PR TITLE
fix issue 462 - MatchError in Output[String] -> Output[NonEmptyString] inference

### DIFF
--- a/core/src/main/scala/besom/util/NonEmptyString.scala
+++ b/core/src/main/scala/besom/util/NonEmptyString.scala
@@ -51,6 +51,10 @@ object NonEmptyString:
           handleParts(parts)
         case '{ scala.StringContext.apply(${ Varargs(parts) }: _*).pulumi(${ Varargs(_) }: _*)(using ${ xd }: Context) } =>
           handleParts(parts)
+        case _ =>
+          report.errorAndAbort(
+            "This is an Output of a dynamic String which can't be inferred to be a NonEmptyString! Use `.flatMap(_.toNonEmptyOutput)` instead."
+          )
 
     end fromStringOutputImpl
 

--- a/core/src/test/scala/besom/util/CompileAssertions.scala
+++ b/core/src/test/scala/besom/util/CompileAssertions.scala
@@ -10,13 +10,13 @@ trait CompileAssertions:
 
   private val NL = System.lineSeparator()
 
-  inline def failsToCompile(inline code: String): Unit =
+  transparent inline def failsToCompile(inline code: String): Unit =
     assert(
       !scala.compiletime.testing.typeChecks(code),
       s"Code compiled correctly when expecting type errors:$NL$code"
     )
 
-  inline def compiles(inline code: String): Unit =
+  transparent inline def compiles(inline code: String): Unit =
     val errors = scala.compiletime.testing.typeCheckErrors(code)
     if errors.nonEmpty then
       val errorMessages = errors.map(_.message).mkString(NL)


### PR DESCRIPTION
pulumi string interpolation inference macro threw MatchError on dynamic Output[String]