### PR TITLE
Allow overriding publishing settings for codegen

### DIFF
--- a/codegen/src/CodeGen.scala
+++ b/codegen/src/CodeGen.scala
@@ -48,6 +48,14 @@ class CodeGen(using
     val scalaVersion     = config.scalaVersion
     val javaVersion      = config.javaVersion
     val coreShortVersion = config.coreShortVersion
+    val organization     = config.organization
+    val url              = config.url
+    val vcs              = config.vcs
+    val license          = config.license
+    val repository       = config.repository
+    val developers       = config.developers
+
+    val developersBlock = developers.map(developer => s"//> using publish.developer \"$developer\"").mkString("\n")
 
     val dependencies = packageDependencies(schemaProvider.dependencies(schemaName, packageVersion))
 
@@ -61,16 +69,13 @@ class CodeGen(using
           |//> using resourceDir "resources"
           |
           |//> using publish.name "besom-${schemaName}"
-          |//> using publish.organization "org.virtuslab"
+          |//> using publish.organization "$organization"
           |//> using publish.version "${packageVersion}-core.${coreShortVersion}"
-          |//> using publish.url "https://github.com/VirtusLab/besom"
-          |//> using publish.vcs "github:VirtusLab/besom"
-          |//> using publish.license "Apache-2.0"
-          |//> using publish.repository "central"
-          |//> using publish.developer "lbialy|Łukasz Biały|https://github.com/lbialy"
-          |//> using publish.developer "prolativ|Michał Pałka|https://github.com/prolativ"
-          |//> using publish.developer "KacperFKorban|Kacper Korban|https://github.com/KacperFKorban"
-          |//> using publish.developer "pawelprazak|Paweł Prażak|https://github.com/pawelprazak"
+          |//> using publish.url "$url"
+          |//> using publish.vcs "$vcs"
+          |//> using publish.license "$license"
+          |//> using publish.repository "$repository"
+          |${developersBlock}
           |""".stripMargin
 
     val filePath = FilePath(Seq("project.scala"))

--- a/codegen/src/Config.scala
+++ b/codegen/src/Config.scala
@@ -11,7 +11,13 @@ case class Config(
   codegenDir: os.Path = Config.DefaultCodegenDir,
   overlaysDir: os.Path = Config.DefaultOverlaysDir,
   outputDir: Option[os.RelPath] = None,
-  providers: String => Config.Provider = Config.DefaultProvidersConfigs
+  providers: String => Config.Provider = Config.DefaultProvidersConfigs,
+  organization: String = Config.DefaultOrganization,
+  url: String = Config.DefaultUrl,
+  vcs: String = Config.DefaultVcs,
+  license: String = Config.DefaultLicense,
+  repository: String = Config.DefaultRepository,
+  developers: List[String] = Config.DefaultDevelopersList
 ):
   val coreShortVersion: String = SemanticVersion
     .parseTolerant(besomVersion)
@@ -54,4 +60,21 @@ object Config {
   )
 
   val DefaultProvidersConfigs: Map[String, Provider] = Map().withDefault(_ => Config.Provider())
+
+  val DefaultOrganization: String = "org.virtuslab"
+
+  val DefaultUrl: String = "https://github.com/VirtusLab/besom"
+
+  val DefaultVcs: String = "github:VirtusLab/besom"
+
+  val DefaultLicense = "Apache-2.0"
+
+  val DefaultRepository = "central"
+
+  val DefaultDevelopersList: List[String] = List(
+    "lbialy|Łukasz Biały|https://github.com/lbialy",
+    "prolativ|Michał Pałka|https://github.com/prolativ",
+    "KacperFKorban|Kacper Korban|https://github.com/KacperFKorban",
+    "pawelprazak|Paweł Prażak|https://github.com/pawelprazak"
+  )
 }

--- a/codegen/src/Main.scala
+++ b/codegen/src/Main.scala
@@ -24,6 +24,19 @@ object Main {
           metadata = PackageMetadata(name, version),
           schema = Some(os.Path(schemaPath))
         )
+      case "schema" :: name :: version :: schemaPath :: organization :: url :: vcs :: license :: repository :: developer :: Nil =>
+        given Config = Config(
+          organization = organization,
+          url = url,
+          vcs = vcs,
+          license = license,
+          repository = repository,
+          developers = List(developer)
+        )
+        generator.generatePackageSources(
+          metadata = PackageMetadata(name, version),
+          schema = Some(os.Path(schemaPath))
+        )
       case _ =>
         System.err.println(
           s"""|Unknown arguments: '${args.mkString(" ")}'
@@ -32,6 +45,7 @@ object Main {
               |  named <name> <version> [outputDir]               - Generate package from name and version
               |  metadata <metadataPath> [outputDir]              - Generate package from metadata file
               |  schema <name> <version> <schemaPath> [outputDir] - Generate package from schema file
+              |  schema <name> <version> <schemaPath> <organization> <url> <vcs> <license> <repository> <developer> [outputDir] - Generate package from schema file
               |""".stripMargin
         )
         sys.exit(1)


### PR DESCRIPTION
At the moment publishing settings for generated sources are hard-coded to besom specific values. However if a developer of a pulumi provider wants to add a first-party support for besom and publish the generated sdk by themselves, they would want to configure these values.

This PR proposes a way to override the publishing settings via cli arguments