### PR TITLE
Pass plugin discoverer output via a temp file

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -412,7 +412,7 @@ compile-codegen: publish-local-model
 	scala-cli --power compile {{no-bloop}} codegen --suppress-experimental-feature-warning
 
 # Runs tests for Besom codegen
-test-codegen: compile-codegen
+test-codegen:
 	scala-cli --power test {{no-bloop}} codegen --suppress-experimental-feature-warning
 
 # Cleans codegen build

--- a/integration-tests/LanguagePluginTest.test.scala
+++ b/integration-tests/LanguagePluginTest.test.scala
@@ -199,10 +199,12 @@ class LanguagePluginTest extends munit.FunSuite {
         clue(actual) == clue(expectedBootstrapPluginsJson)
       }
 
+    val pulumiUpEnv = ctx.env + ("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION" -> "false")
+
     val pulumiUpOutput =
       pulumi
         .up(ctx.stackName, "--skip-preview")
-        .call(cwd = ctx.programDir, env = ctx.env)
+        .call(cwd = ctx.programDir, env = pulumiUpEnv)
         .out
         .text()
 

--- a/integration-tests/LanguagePluginTest.test.scala
+++ b/integration-tests/LanguagePluginTest.test.scala
@@ -283,7 +283,7 @@ class LanguagePluginTest extends munit.FunSuite {
       projectFiles = Map("build.sbt" -> sbtBuildFile)
     ),
     teardown = pulumi.fixture.teardown
-  ).test("sbt".tag(LocalOnly)) { ctx =>
+  ).test("sbt") { ctx =>
     testExecutor(ctx)
   }
 

--- a/integration-tests/LanguagePluginTest.test.scala
+++ b/integration-tests/LanguagePluginTest.test.scala
@@ -199,12 +199,10 @@ class LanguagePluginTest extends munit.FunSuite {
         clue(actual) == clue(expectedBootstrapPluginsJson)
       }
 
-    val pulumiUpEnv = ctx.env + ("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION" -> "false")
-
     val pulumiUpOutput =
       pulumi
         .up(ctx.stackName, "--skip-preview")
-        .call(cwd = ctx.programDir, env = pulumiUpEnv)
+        .call(cwd = ctx.programDir, env = ctx.env)
         .out
         .text()
 

--- a/language-plugin/bootstrap/PulumiPlugins.scala
+++ b/language-plugin/bootstrap/PulumiPlugins.scala
@@ -40,8 +40,9 @@ object PulumiPluginsDiscoverer:
     JsArray(foundPlugins.values.toVector).compactPrint
 
   private def writeToFile(path: String, text: String): Unit =
-    val file = new File(path)
+    val file   = new File(path)
     val writer = new PrintWriter(file)
 
     writer.write(text)
     writer.close()
+end PulumiPluginsDiscoverer

--- a/language-plugin/bootstrap/PulumiPlugins.scala
+++ b/language-plugin/bootstrap/PulumiPlugins.scala
@@ -2,13 +2,20 @@ package besom.bootstrap
 
 import scala.util.Using
 import scala.jdk.CollectionConverters.*
+import java.io.{File, PrintWriter}
 import io.github.classgraph.ClassGraph
 import besom.json.*
 
 object PulumiPluginsDiscoverer:
   def main(args: Array[String]): Unit =
-    val foundPlugins = pluginsFromClasspath
-    print(JsArray(foundPlugins.values.toVector).compactPrint)
+    args.toList match
+      case Nil =>
+        print(pluginsJsonText)
+      case "--output-file" :: outputFilePath :: Nil =>
+        writeToFile(path = outputFilePath, text = pluginsJsonText)
+      case _ =>
+        Console.err.println(s"PulumiPluginDiscoverer: Wrong main arguments: ${args.mkString(",")}")
+        sys.exit(1)
 
   private val PluginRegex = "^(besom/(.+))/plugin.json$".r
 
@@ -27,3 +34,14 @@ object PulumiPluginsDiscoverer:
     new ClassGraph()
       .filterClasspathElements(_ => true) // todo exclude garbage
       .scan()
+
+  private def pluginsJsonText =
+    val foundPlugins = pluginsFromClasspath
+    JsArray(foundPlugins.values.toVector).compactPrint
+
+  private def writeToFile(path: String, text: String): Unit =
+    val file = new File(path)
+    val writer = new PrintWriter(file)
+
+    writer.write(text)
+    writer.close()

--- a/language-plugin/bootstrap/project.scala
+++ b/language-plugin/bootstrap/project.scala
@@ -2,6 +2,6 @@
 //> using options -java-output-version:11
 
 //> using dep org.virtuslab::besom-json:0.4.0-SNAPSHOT
-//> using dep io.github.classgraph:classgraph:4.8.165
+//> using dep io.github.classgraph:classgraph:4.8.176
 
 

--- a/language-plugin/pulumi-language-scala/executors/executor.go
+++ b/language-plugin/pulumi-language-scala/executors/executor.go
@@ -4,6 +4,7 @@ package executors
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/virtuslab/besom/language-host/fsys"
 )
@@ -93,4 +94,10 @@ func (c combinedScalaExecutorFactory) NewScalaExecutor(opts ScalaExecutorOptions
 
 func combineScalaExecutorFactories(variations ...scalaExecutorFactory) scalaExecutorFactory {
 	return combinedScalaExecutorFactory(variations)
+}
+
+const PluginDiscovererOutputFileName = ".besom-pulumi-plugins.json"
+
+func PluginDiscovererOutputFilePath(projectRoot fsys.ParentFS) string {
+	return path.Join(projectRoot.Path(), PluginDiscovererOutputFileName)
 }

--- a/language-plugin/pulumi-language-scala/executors/executor_jar.go
+++ b/language-plugin/pulumi-language-scala/executors/executor_jar.go
@@ -25,10 +25,11 @@ func (j jarexec) NewScalaExecutor(opts ScalaExecutorOptions) (*ScalaExecutor, er
 	if err != nil {
 		return nil, err
 	}
-	return j.newJarExecutor(cmd, opts.BootstrapLibJarPath, opts.Binary)
+	pluginDiscovererOutputPath := PluginDiscovererOutputFilePath(opts.WD)
+	return j.newJarExecutor(cmd, opts.BootstrapLibJarPath, opts.Binary, pluginDiscovererOutputPath)
 }
 
-func (jarexec) newJarExecutor(cmd string, bootstrapLibJarPath string, rawBinaryPath string) (*ScalaExecutor, error) {
+func (jarexec) newJarExecutor(cmd string, bootstrapLibJarPath string, rawBinaryPath string, pluginDiscovererOutputPath string) (*ScalaExecutor, error) {
 	binaryPath := filepath.Clean(rawBinaryPath)
 	classPath := bootstrapLibJarPath + ":" + binaryPath
 
@@ -37,7 +38,7 @@ func (jarexec) newJarExecutor(cmd string, bootstrapLibJarPath string, rawBinaryP
 		Cmd:         cmd,
 		BuildArgs:   nil, // not supported
 		RunArgs:     []string{"-jar", binaryPath},
-		PluginArgs:  []string{"-cp", classPath, "besom.bootstrap.PulumiPluginsDiscoverer"},
+		PluginArgs:  []string{"-cp", classPath, "besom.bootstrap.PulumiPluginsDiscoverer", "--output-file", pluginDiscovererOutputPath},
 		VersionArgs: []string{"-version"},
 	}, nil
 }

--- a/language-plugin/pulumi-language-scala/executors/executor_maven.go
+++ b/language-plugin/pulumi-language-scala/executors/executor_maven.go
@@ -29,7 +29,8 @@ func (m maven) NewScalaExecutor(opts ScalaExecutorOptions) (*ScalaExecutor, erro
 	if err != nil {
 		return nil, err
 	}
-	executor, err := m.newMavenExecutor(cmd, opts.BootstrapLibJarPath)
+	pluginDiscovererOutputPath := PluginDiscovererOutputFilePath(opts.WD)
+	executor, err := m.newMavenExecutor(cmd, opts.BootstrapLibJarPath, pluginDiscovererOutputPath)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (maven) isMavenProject(opts ScalaExecutorOptions) (bool, error) {
 	return fsys.FileExists(opts.WD, "pom.xml")
 }
 
-func (maven) newMavenExecutor(cmd string, bootstrapLibJarPath string) (*ScalaExecutor, error) {
+func (maven) newMavenExecutor(cmd string, bootstrapLibJarPath string, pluginDiscovererOutputPath string) (*ScalaExecutor, error) {
 	return &ScalaExecutor{
 		Name: "maven",
 		Cmd:  cmd,
@@ -75,12 +76,11 @@ func (maven) newMavenExecutor(cmd string, bootstrapLibJarPath string) (*ScalaExe
 			"scala:run",
 		},
 		PluginArgs: []string{
-			/* move normal output to STDERR, because we need STDOUT for JSON with plugin results */
-			"-Dorg.slf4j.simpleLogger.logFile=System.err",
 			"--no-transfer-progress",
 			"-DbesomBootstrapJar=" + bootstrapLibJarPath,
 			"-DmainClass=besom.bootstrap.PulumiPluginsDiscoverer",
 			"scala:run",
+			"-DaddArgs=--output-file|" + pluginDiscovererOutputPath,
 		},
 		VersionArgs: []string{"--version"},
 	}, nil

--- a/language-plugin/pulumi-language-scala/executors/executor_scala_cli.go
+++ b/language-plugin/pulumi-language-scala/executors/executor_scala_cli.go
@@ -21,17 +21,18 @@ func (s scalacli) NewScalaExecutor(opts ScalaExecutorOptions) (*ScalaExecutor, e
 	if err != nil {
 		return nil, err
 	}
-	return s.newScalaCliExecutor(cmd, opts.BootstrapLibJarPath)
+	pluginDiscovererOutputPath := PluginDiscovererOutputFilePath(opts.WD)
+	return s.newScalaCliExecutor(cmd, opts.BootstrapLibJarPath, pluginDiscovererOutputPath)
 }
 
-func (scalacli) newScalaCliExecutor(cmd string, bootstrapLibJarPath string) (*ScalaExecutor, error) {
+func (scalacli) newScalaCliExecutor(cmd string, bootstrapLibJarPath string, pluginDiscovererOutputPath string) (*ScalaExecutor, error) {
 	scalaCliOpts := os.Getenv("BESOM_LANGHOST_SCALA_CLI_OPTS")
 	return &ScalaExecutor{
 		Name:        "scala-cli",
 		Cmd:         cmd,
 		BuildArgs:   []string{"compile", ".", scalaCliOpts},
 		RunArgs:     []string{"run", ".", scalaCliOpts},
-		PluginArgs:  []string{"run", ".", scalaCliOpts, "--jar", bootstrapLibJarPath, "--main-class", "besom.bootstrap.PulumiPluginsDiscoverer"},
+		PluginArgs:  []string{"run", ".", scalaCliOpts, "--jar", bootstrapLibJarPath, "--main-class", "besom.bootstrap.PulumiPluginsDiscoverer", "--", "--output-file", pluginDiscovererOutputPath},
 		VersionArgs: []string{"version", "--cli", "--offline"},
 	}, nil
 }


### PR DESCRIPTION
Build tools might add some garbage to stdout while running the plugin discoverer.
Printing the result's json into a file should solve this problem and make plugins discovery more reliable.

Also bumping pulumi version used in CI