### PR TITLE
Fix inverted is-snapshot guard in upsert-gh-release

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -611,9 +611,10 @@ cli *ARGS:
 upsert-gh-release:
 	#!/usr/bin/env sh
 	if {{is-snapshot}}; then
-		echo "Not a snapshot version, refusing to delete a release"
-	else
 		gh release delete v{{besom-version}} --yes || echo "Nothing to delete"
+	else
+		echo "Not a snapshot version, refusing to delete a release"
+		exit 1
 	fi
 	echo Creating release v{{besom-version}}
 	gh release create v{{besom-version}} --title v{{besom-version}} --notes "" --prerelease --draft


### PR DESCRIPTION
## Summary
- Fix inverted `is-snapshot` condition in `upsert-gh-release` that was deleting real releases instead of protecting them
- Add `exit 1` to the refusal branch so `just` stops instead of continuing to create a new release

Fixes #593